### PR TITLE
fix: the api7 container port mapping is invalid

### DIFF
--- a/chart/api7/templates/service.yaml
+++ b/chart/api7/templates/service.yaml
@@ -42,7 +42,7 @@ spec:
   {{- if .Values.gateway.http.enabled }}
   - name: api7-gateway
     port: {{ .Values.gateway.http.servicePort }}
-    targetPort: {{ .Values.gateway.http.containerPort }}
+    targetPort: {{ .Values.gateway.http.port }}
   {{- if (and (eq .Values.gateway.type "NodePort") (not (empty .Values.gateway.http.nodePort))) }}
     nodePort: {{ .Values.gateway.http.nodePort }}
   {{- end }}
@@ -51,7 +51,7 @@ spec:
   {{- if .Values.gateway.tls.enabled }}
   - name: api7-gateway-tls
     port: {{ .Values.gateway.tls.servicePort }}
-    targetPort: {{ .Values.gateway.tls.containerPort }}
+    targetPort: {{ .Values.gateway.tls.port }}
   {{- if (and (eq .Values.gateway.type "NodePort") (not (empty .Values.gateway.tls.nodePort))) }}
     nodePort: {{ .Values.gateway.tls.nodePort }}
   {{- end }}


### PR DESCRIPTION
The container port key in the values.yaml file is as follows:

https://github.com/api7/api7-helm-chart/blob/26407a4aa504d265ea4e2efc7fb8f7c52508bf3d/chart/api7/values.yaml#L50-L58