### PR TITLE
fix: incorrect FQDN address when prometheus component is builtin

### DIFF
--- a/chart/api7-dashboard/templates/configmap.yaml
+++ b/chart/api7-dashboard/templates/configmap.yaml
@@ -63,7 +63,7 @@ data:
       prometheus:
         host:
         {{- if .Values.prometheus.builtin }}
-        - "https://{{ .Release.Name }}-prometheus-server.{{ .Release.Name }}.svc.{{ .Values.clusterDomain }}:80"
+        - "http://{{ .Release.Name }}-prometheus-server.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:80"
         {{- else -}}
           {{ range .Values.prometheus.clusters }}
         - {{ . }}


### PR DESCRIPTION
As described in the title.