### PR TITLE
fix: replace \t with space in api7-dashboard configmap template

### DIFF
--- a/chart/api7-dashboard/templates/configmap.yaml
+++ b/chart/api7-dashboard/templates/configmap.yaml
@@ -139,7 +139,7 @@ data:
           file_path:
             {{ .Values.config.log.access_log.file_path }}  # supports relative path, absolute path, standard output
                             # such as: logs/access.log, /tmp/logs/access.log, /dev/stdout, /dev/stderr
-                            # log example: 2020-12-09T16:38:09.039+0800	INFO	filter/logging.go:46	/apisix/admin/routes/r1	{"status": 401, "host": "127.0.0.1:9000", "query": "asdfsafd=adf&a=a", "requestId": "3d50ecb8-758c-46d1-af5b-cd9d1c820156", "latency": 0, "remoteIP": "127.0.0.1", "method": "PUT", "errs": []}
+                            # log example: 2020-12-09T16:38:09.039+0800 INFO filter/logging.go:46 /apisix/admin/routes/r1 {"status": 401, "host": "127.0.0.1:9000", "query": "asdfsafd=adf&a=a", "requestId": "3d50ecb8-758c-46d1-af5b-cd9d1c820156", "latency": 0, "remoteIP": "127.0.0.1", "method": "PUT", "errs": []}
     authentication:
       secret:
         {{ .Values.config.authentication.secret }}  # secret for jwt token generation.


### PR DESCRIPTION
fix: replace \t with space in api7-dashboard configmap template, this will cause the kubectl configmap yaml output to be unformatted.
Before fix:
![image](https://user-images.githubusercontent.com/22141303/138816231-878bddde-7378-4558-b78c-9e369c55ad66.png)
After fix:
![image](https://user-images.githubusercontent.com/22141303/138816329-c1431900-a1d5-40c7-9b76-66a7292cea59.png)
