### PR TITLE
feat: support install api7-gateway in standalone mode

### DIFF
--- a/charts/api7-gateway/Chart.lock
+++ b/charts/api7-gateway/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: etcd
+  repository: https://charts.bitnami.com/bitnami
+  version: 8.3.3
+digest: sha256:e580dc3bb27b249f3d0261b5db899b606750aee200a13fb7cdd37eb63a07e23f
+generated: "2023-10-18T11:28:31.769531153+08:00"

--- a/charts/api7-gateway/Chart.yaml
+++ b/charts/api7-gateway/Chart.yaml
@@ -25,3 +25,8 @@ appVersion: 2.8.2206.1
 maintainers:
   - email: chaozhang@api7.ai
     name: Chao Zhang
+dependencies:
+  - name: etcd
+    version: 8.3.3
+    repository: https://charts.bitnami.com/bitnami
+    condition: etcd.builtin

--- a/charts/api7-gateway/templates/configmap.yaml
+++ b/charts/api7-gateway/templates/configmap.yaml
@@ -39,9 +39,9 @@ data:
     #
     apisix:
       node_listen: {{ .Values.gateway.http.port }}
-      lua_module_hook: "apisix.enterprise.init"
+      lua_module_hook: {{ .Values.gateway.luaModuleHook }}
       enable_heartbeat: true
-      enable_admin: false
+      enable_admin: {{ .Values.admin.enabled }}
       enable_admin_cors: true
       enable_debug: false
       enable_dev_mode: false          # Sets nginx worker_processes to 1 if set to true
@@ -159,28 +159,60 @@ data:
       stream_configuration_snippet: {{ toYaml .Values.configurationSnippet.stream | indent 6 }}
       {{- end }}
 
-    etcd:
-    {{- if .Values.etcd.builtin }}
-      host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
-        - "http://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.etcd.service.port }}"
-    {{- else }}
-      host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
-        {{- range $value := .Values.etcd.hosts }}
-        - "{{ $value }}"             # multiple etcd address
+    deployment:
+      {{- if .Values.admin.enabled }}
+      admin:
+        allow_admin:
+        {{- if .Values.admin.allow.ipList }}
+        {{- range $ips := .Values.admin.allow.ipList }}
+          - {{ $ips }}
         {{- end }}
-    {{- end }}
-      prefix: {{ .Values.etcd.prefix | quote }}     # apisix configurations prefix
-      timeout: {{ .Values.etcd.timeout }}   # 30 seconds
-      {{- if .Values.etcd.auth.rbac.enabled }}
-      user: {{ .Values.etcd.auth.rbac.user | quote }}
-      password: {{ .Values.etcd.auth.rbac.password | quote }}
+        {{- else }}
+          - 0.0.0.0/0
+        {{- end}}
+        admin_listen:
+          ip: {{ .Values.admin.ip }}
+          port: {{ .Values.admin.port }}
+        admin_key:
+        # admin: can everything for configuration data
+        - name: "admin"
+        {{- if .Values.admin.credentials.secretName }}
+          key: ${{"{{"}}APISIX_ADMIN_KEY{{"}}"}}
+        {{- else }}
+          key: {{ .Values.admin.credentials.admin }}
+        {{- end }}
+          role: admin
+        # viewer: only can view configuration data
+        - name: "viewer"
+        {{- if .Values.admin.credentials.secretName }}
+          key: ${{"{{"}}APISIX_VIEWER_KEY{{"}}"}}
+        {{- else }}
+          key: {{ .Values.admin.credentials.viewer }}
+        {{- end }}
+          role: viewer
       {{- end }}
-      {{- if .Values.etcd.auth.tls.enabled }}
-      tls:
-        cert: "/etcd-ssl/{{ .Values.etcd.auth.tls.certFilename }}"
-        key: "/etcd-ssl/{{ .Values.etcd.auth.tls.certKeyFilename }}"
-        verify: {{ .Values.etcd.auth.tls.verify }}
+      etcd:
+      {{- if .Values.etcd.builtin }}
+        host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
+          - "http://{{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:{{ .Values.etcd.service.ports.client }}"
+      {{- else }}
+        host:                                 # it's possible to define multiple etcd hosts addresses of the same etcd cluster.
+          {{- range $value := .Values.etcd.hosts }}
+          - "{{ $value }}"             # multiple etcd address
+          {{- end }}
       {{- end }}
+        prefix: {{ .Values.etcd.prefix | quote }}     # apisix configurations prefix
+        timeout: {{ .Values.etcd.timeout }}   # 30 seconds
+        {{- if .Values.etcd.auth.rbac.enabled }}
+        user: {{ .Values.etcd.auth.rbac.user | quote }}
+        password: {{ .Values.etcd.auth.rbac.password | quote }}
+        {{- end }}
+        {{- if .Values.etcd.auth.tls.enabled }}
+        tls:
+          cert: "/etcd-ssl/{{ .Values.etcd.auth.tls.certFilename }}"
+          key: "/etcd-ssl/{{ .Values.etcd.auth.tls.certKeyFilename }}"
+          verify: {{ .Values.etcd.auth.tls.verify }}
+        {{- end }}
 
     {{- if .Values.discovery.enabled }}
     discovery:

--- a/charts/api7-gateway/templates/deployment.yaml
+++ b/charts/api7-gateway/templates/deployment.yaml
@@ -109,13 +109,33 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
+            {{- if .Values.admin.credentials.secretName }}
+            - name: APISIX_ADMIN_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.admin.credentials.secretName | quote }}
+                  {{- if .Values.admin.credentials.secretAdminKey }}
+                  key: {{- .Values.admin.credentials.secretAdminKey }}
+                  {{- else }}
+                  key: {{- "admin" }}
+                  {{- end }}
+            - name: APISIX_VIEWER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.admin.credentials.secretName | quote }}
+                  {{- if .Values.admin.credentials.secretViewerKey }}
+                  key: {{- .Values.admin.credentials.secretViewerKey }}
+                  {{- else }}
+                  key: {{- "viewer" }}
+                  {{- end }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- if .Values.etcd.builtin }}
       initContainers:
       - name: wait-etcd
         image: "{{ .Values.busybox.image.registry }}/{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"
-        command: ['sh', '-c', "until nc -zw 1 {{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} {{ .Values.etcd.defaultPort }}; do echo waiting for etcd `date`; sleep 2; done;"]
+        command: ['sh', '-c', "until nc -zw 1 {{ .Release.Name }}-etcd.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} {{ .Values.etcd.service.ports.client }}; do echo waiting for etcd `date`; sleep 2; done;"]
       {{- end }}
       volumes:
         - configMap:

--- a/charts/api7-gateway/templates/service-admin.yaml
+++ b/charts/api7-gateway/templates/service-admin.yaml
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.admin.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "api7.fullname" . }}-admin
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- range $key, $value := .Values.admin.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  labels:
+    {{- include "api7.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.admin.type }}
+  {{- if eq .Values.admin.type "LoadBalancer" }}
+  {{- if .Values.admin.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.admin.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.admin.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .Values.admin.loadBalancerSourceRanges }}
+  - {{ $cidr }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  ports:
+  - name: api7-gateway
+    port: {{ .Values.admin.servicePort }}
+    targetPort: {{ .Values.admin.port }}
+  {{- if (and (eq .Values.admin.type "NodePort") (not (empty .Values.admin.nodePort))) }}
+    nodePort: {{ .Values.admin.nodePort }}
+  {{- end }}
+    protocol: TCP
+  selector:
+    {{- include "api7.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/api7-gateway/values.yaml
+++ b/charts/api7-gateway/values.yaml
@@ -60,6 +60,34 @@ nginx:
   workerConnections: "10620"
   enableCPUAffinity: true
 
+admin:
+  enabled: true
+  ip: 0.0.0.0
+  port: 9180
+  servicePort: 9180
+#  nodePort: 9180
+  type: ClusterIP
+  annotations: {}
+  loadBalancerIP: ""
+#  loadBalancerSourceRanges: []
+  # -- Admin API credentials
+  credentials:
+    # -- Apache APISIX admin API admin role credentials
+    admin: edd1c9f034335f136f87ad84b625c8f1
+    # -- Apache APISIX admin API viewer role credentials
+    viewer: 4054f7cf07e344346cd3f287985e76a2
+    # -- The APISIX Helm chart supports storing user credentials in a secret.
+    # The secret needs to contain two keys, admin and viewer, with their respective values set.
+    secretName: ""
+    # -- Name of the admin role key in the secret, overrides the default key name "admin"
+    secretAdminKey: ""
+    # -- Name of the viewer role key in the secret, overrides the default key name "viewer"
+    secretViewerKey: ""
+  allow:
+    # -- The client IP CIDR allowed to access Apache APISIX Admin API service.
+    ipList:
+      - 127.0.0.1/24
+
 gateway:
   # Enable nginx IPv6 resolver
   enableIPv6: true
@@ -97,6 +125,7 @@ gateway:
   #  - secretName: apisix-tls
   #    hosts:
   #      - chart-example.local
+  luaModuleHook: "apisix.enterprise.init"
 
 # etcd configuration
 # use the FQDN address or the IP of the etcd
@@ -104,31 +133,34 @@ etcd:
   # install etcd(v3) by default, set false if do not want to install etcd(v3) together,
   # in such a case, etcd.host should be configured so that existing ETCD cluster can be
   # used.
-  builtin: false
+  builtin: true
+  replicaCount: 1
   hosts:
-    - http://etcd.host:2379 # host or ip e.g. http://172.20.128.89:2379
+    - http://etcd.api7.svc.cluster.local:2379 # host or ip e.g. http://172.20.128.89:2379
   prefix: "/api7"
   timeout: 30
-  defaultPort: 2379
+  service:
+    ports:
+      client: 2379
   auth:
     rbac:
       # No authentication by default
       enabled: false
+      create: false
       ## etcd user
-      ##
       user: ""
       ## etcd password
-      ##
       password: ""
     # Whether to set up secure transport to ETCD cluster.
     tls:
-      enalbed: false
+      enabled: false
       # An existing secret stores the credentials to communicate with ETCD cluster.
       existingSecret: ""
       # Certificate filename used to communicate ETCD cluster.
       certFilename: "tls.crt"
       # Private key filename used to communicate ETCD cluster.
       certKeyFilename: "tls.key"
+      certCAFilename: "ca.crt"
       verify: true
 
 discovery:


### PR DESCRIPTION
Usage:
```bash
helm install api7-standalone ./charts/api7-gateway \
  --set image.registry=asia-east2-docker.pkg.dev \
  --set image.repository=molten-verve-356604/api7/api7-gateway \
  --set image.tag=3.2.3.1 \
  --set gateway.luaModuleHook="" \
  --set admin.allow.ipList="{0.0.0.0/0}" \
  --set admin.enabled=true \
  --set etcd.replicaCount=3
```