### PR TITLE
feat: configurable ingress backend

### DIFF
--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.5
+version: 0.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -1,6 +1,6 @@
 # api7ee3
 
-![Version: 0.14.5](https://img.shields.io/badge/Version-0.14.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -67,19 +67,18 @@ A Helm chart for Kubernetes
 | developer_portal.image.pullPolicy | string | `"IfNotPresent"` |  |
 | developer_portal.image.repository | string | `"api7/api7-developer-portal"` |  |
 | developer_portal.image.tag | string | `"v0.0.5"` |  |
-| developer_portal.ingress.annotations | object | `{}` |  |
-| developer_portal.ingress.className | string | `""` |  |
-| developer_portal.ingress.enabled | bool | `false` |  |
-| developer_portal.ingress.hosts[0].host | string | `"developer-portal.local"` |  |
-| developer_portal.ingress.hosts[0].paths[0].path | string | `"/"` |  |
-| developer_portal.ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
-| developer_portal.ingress.tls | list | `[]` |  |
-| developer_portal.port | int | `4321` |  |
 | developer_portal.replicaCount | int | `1` |  |
 | developer_portal_configuration.enable | bool | `true` |  |
 | developer_portal_configuration.server.listen.host | string | `"0.0.0.0"` |  |
 | developer_portal_configuration.server.listen.port | int | `4321` |  |
 | developer_portal_configuration.server.listen.tls.enabled | bool | `true` |  |
+| developer_portal_service.ingress.annotations | object | `{}` |  |
+| developer_portal_service.ingress.className | string | `""` |  |
+| developer_portal_service.ingress.enabled | bool | `false` |  |
+| developer_portal_service.ingress.hosts[0].host | string | `"developer-portal.local"` |  |
+| developer_portal_service.ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| developer_portal_service.ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
+| developer_portal_service.ingress.tls | list | `[]` |  |
 | developer_portal_service.port | int | `4321` |  |
 | developer_portal_service.type | string | `"ClusterIP"` |  |
 | dp_manager.extraEnvVars | list | `[]` |  |

--- a/charts/api7/templates/dashboard-ingress.yaml
+++ b/charts/api7/templates/dashboard-ingress.yaml
@@ -52,6 +52,9 @@ spec:
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
             {{- end }}
+            {{- if .backend }}
+            backend: {{ toYaml .backend | nindent 14 }}
+            {{- else }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
@@ -62,6 +65,7 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
               {{- end }}
+            {{- end}}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/api7/templates/developer-portal-ingress.yaml
+++ b/charts/api7/templates/developer-portal-ingress.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.developer_portal.ingress.enabled }}
+{{- if .Values.developer_portal_service.ingress.enabled }}
 {{- $fullName := printf "%s-developer-portal" (include "api7ee3.fullname" .) -}}
-{{- $svcPort := .Values.developer_portal.port -}}
-{{- if and .Values.developer_portal.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.developer_portal.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.developer_portal.ingress.annotations "kubernetes.io/ingress.class" .Values.developer_portal.ingress.className}}
+{{- $svcPort := .Values.developer_portal_service.port -}}
+{{- if and .Values.developer_portal_service.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.developer_portal_service.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.developer_portal_service.ingress.annotations "kubernetes.io/ingress.class" .Values.developer_portal_service.ingress.className}}
   {{- end }}
 {{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -18,17 +18,17 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "api7ee3.labels" . | nindent 4 }}
-  {{- with .Values.developer_portal.ingress.annotations }}
+  {{- with .Values.developer_portal_service.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.developer_portal.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.developer_portal.ingress.className }}
+  {{- if and .Values.developer_portal_service.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.developer_portal_service.ingress.className }}
   {{- end }}
-  {{- if .Values.developer_portal.ingress.tls }}
+  {{- if .Values.developer_portal_service.ingress.tls }}
   tls:
-    {{- range .Values.developer_portal.ingress.tls }}
+    {{- range .Values.developer_portal_service.ingress.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . | quote }}
@@ -37,7 +37,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.developer_portal.ingress.hosts }}
+    {{- range .Values.developer_portal_service.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
@@ -46,6 +46,9 @@ spec:
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
             {{- end }}
+            {{- if .backend }}
+            backend: {{ toYaml .backend | nindent 14 }}
+            {{- else }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
@@ -56,6 +59,7 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
               {{- end }}
+            {{- end}}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/api7/templates/dp-manager-ingress.yaml
+++ b/charts/api7/templates/dp-manager-ingress.yaml
@@ -46,6 +46,9 @@ spec:
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
             pathType: {{ .pathType }}
             {{- end }}
+            {{- if .backend }}
+            backend: {{ toYaml .backend | nindent 14 }}
+            {{- else }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
@@ -56,6 +59,7 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
               {{- end }}
+            {{- end}}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -30,22 +30,6 @@ developer_portal:
     # Overrides the image tag whose default is the chart appVersion.
     tag: "v0.0.5"
   extraEnvVars: []
-  port: 4321
-  ingress:
-    enabled: false
-    className: ""
-    annotations: {}
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
-    hosts:
-      - host: developer-portal.local
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
-    tls: []
-    #  - secretName: developer-portal-tls
-    #    hosts:
-    #      - developer-portal.local
     
 
 imagePullSecret: ""
@@ -117,6 +101,21 @@ dp_manager_service:
 developer_portal_service:
   type: ClusterIP
   port: 4321
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    hosts:
+      - host: developer-portal.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls: []
+    #  - secretName: developer-portal-tls
+    #    hosts:
+    #      - developer-portal.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -73,6 +73,11 @@ dashboard_service:
         paths:
           - path: /
             pathType: ImplementationSpecific
+            # backend:
+            #   service:
+            #     name: api7ee3-dashboard
+            #     port:
+            #       number: 7943
     tls: []
     #  - secretName: dashboard-tls
     #    hosts:
@@ -93,6 +98,11 @@ dp_manager_service:
         paths:
           - path: /
             pathType: ImplementationSpecific
+            # backend:
+            #   service:
+            #     name: api7ee3-dp-manager
+            #     port:
+            #       number: 7943
     tls: []
     #  - secretName: dp-manager-tls
     #    hosts:
@@ -112,6 +122,11 @@ developer_portal_service:
         paths:
           - path: /
             pathType: ImplementationSpecific
+            # backend:
+            #   service:
+            #     name: api7ee3-developer-portal
+            #     port:
+            #       number: 7943
     tls: []
     #  - secretName: developer-portal-tls
     #    hosts:


### PR DESCRIPTION
Currently, ingress assumes that deployments do not use TLS and only configure HTTP ports, which can be insecure, so this PR changes the port part to be configurable.
If the user provides the backend key along with the paths' items, it will be set in ingress, otherwise the backend is generated from the default port according to the original logic.

Also, the developer portal ingress had been placed in an inappropriate location, now it has been moved under developer_portal_service, same as the other components. If users have been using the default configuration, this change will be insensitive.