### PR TITLE
feat: configure resources for the dashboard and dp-manager deployments respectively

### DIFF
--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.2
+version: 0.16.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/api7/templates/dashboard-deploy.yaml
+++ b/charts/api7/templates/dashboard-deploy.yaml
@@ -109,7 +109,11 @@ spec:
           {{- include "api7ee3.tplvalues.render" (dict "value" .Values.dashboard.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
           resources:
+            {{- if .Values.dashboard.resources }}
+            {{- toYaml .Values.dashboard.resources | nindent 12 }}
+            {{- else }}
             {{- toYaml .Values.resources | nindent 12 }}
+            {{- end }}
           env:
           {{- if .Values.dashboard.extraEnvVars }}
           {{- include "api7ee3.tplvalues.render" (dict "value" .Values.dashboard.extraEnvVars "context" $) | nindent 12 }}

--- a/charts/api7/templates/dp-manager-deploy.yaml
+++ b/charts/api7/templates/dp-manager-deploy.yaml
@@ -94,7 +94,11 @@ spec:
           {{- include "api7ee3.tplvalues.render" (dict "value" .Values.dashboard.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
           resources:
+            {{- if .Values.dp_manager.resources }}
+            {{- toYaml .Values.dp_manager.resources | nindent 12 }}
+            {{- else }}
             {{- toYaml .Values.resources | nindent 12 }}
+            {{- end }}
           env:
           {{- if .Values.dp_manager.extraEnvVars }}
           {{- include "api7ee3.tplvalues.render" (dict "value" .Values.dp_manager.extraEnvVars "context" $) | nindent 12 }}

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -11,6 +11,18 @@ dashboard:
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: "v3.2.14.2"
+  # Resources of the deployment.
+  # It has a higher priority than the common resources configuration:
+  # when this field is configured, it is used first in the deployment,
+  # otherwise the common resources configuration is used.
+  # resources:
+  #   limits:
+  #     cpu: 100m
+  #     memory: 128Mi
+  #   requests:
+  #     cpu: 100m
+  #     memory: 128Mi
+
   extraEnvVars: []
   extraVolumes: []
   extraVolumeMounts: []
@@ -22,6 +34,18 @@ dp_manager:
     pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
     tag: "v3.2.14.2"
+  # Resources of the deployment.
+  # It has a higher priority than the common resources configuration:
+  # when this field is configured, it is used first in the deployment,
+  # otherwise the common resources configuration is used.
+  # resources:
+  #   limits:
+  #     cpu: 100m
+  #     memory: 128Mi
+  #   requests:
+  #     cpu: 100m
+  #     memory: 128Mi
+
   extraEnvVars: []
   extraVolumes: []
   extraVolumeMounts: []

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9
+version: 0.1.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Configure resources separately for dashboard and dp-manager deployments and use your own configuration first, or use the public one if you don't have one.