### PR TITLE
support multiline access log format

### DIFF
--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -151,7 +151,8 @@ data:
         enable_access_log: {{ .Values.logs.enableAccessLog }}
         {{- if .Values.logs.enableAccessLog }}
         access_log: "{{ .Values.logs.accessLog }}"
-        access_log_format: '{{ .Values.logs.accessLogFormat }}'
+        access_log_format: >-
+          {{ .Values.logs.accessLogFormat | nindent 10 }}
         access_log_format_escape: {{ .Values.logs.accessLogFormatEscape }}
         {{- end }}
         keepalive_timeout: 60s         # timeout during which a keep-alive client connection will stay open on the server side.


### PR DESCRIPTION
This change adds support for multiline access log format like this json format:

```yaml
logs:
  accessLogFormatEscape: json
  accessLogFormat: >-
    {
      "timestamp": "$time_iso8601",
      "http": {
        "request": {
          "id": "$request_id",
          "method": "$request_method",
          "length": "$request_length",
          "user_agent": "$http_user_agent",
          "address": "$remote_addr",
          "referer": "$http_referer",
          "protocol": "$server_protocol",
          "body_size": "$body_bytes_sent",
          "latency": "$request_time s"
        },
        "response": {
          "size": "$upstream_response_length",
          "status_code": $status,
          "latency": "$upstream_response_time s"
        }
      },
      "upstream": {
        "address": "$upstream_addr",
        "connect_time": "$upstream_connect_time s",
        "header_time": "$upstream_header_time s",
        "response": {
          "latency": "$upstream_response_time s",
          "status_code": $upstream_status
        }
      },
      "url": {
        "domain": "$host",
        "full": "$host$request_uri",
        "path": "$request_uri",
        "port": "$remote_port",
        "scheme": "$scheme"
      },
      "trace": {
        "id": "$opentelemetry_trace_id"
      }
    }
```