### PR TITLE
fix: PodDisruptionBudget api version

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.10
+version: 0.2.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gateway/templates/pdb.yaml
+++ b/charts/gateway/templates/pdb.yaml
@@ -1,6 +1,10 @@
 
 {{- if (and .Values.apisix.enabled .Values.apisix.podDisruptionBudget.enabled) }}
+{{ if semverCompare "<1.21-0" .Capabilities.KubeVersion.Version -}}
 apiVersion: policy/v1beta1
+{{- else -}}
+apiVersion: policy/v1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "apisix.fullname" . }}


### PR DESCRIPTION
policy/v1beta1 has been removed from k8s 1.25