### PR TITLE
fix: bad indent for access log format

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.11
+version: 0.2.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -152,7 +152,7 @@ data:
         {{- if .Values.logs.enableAccessLog }}
         access_log: "{{ .Values.logs.accessLog }}"
         access_log_format: >-
-          {{ .Values.logs.accessLogFormat | nindent 10 }}
+          {{- .Values.logs.accessLogFormat | nindent 10 }}
         access_log_format_escape: {{ .Values.logs.accessLogFormatEscape }}
         {{- end }}
         keepalive_timeout: 60s         # timeout during which a keep-alive client connection will stay open on the server side.


### PR DESCRIPTION
use `kubectl get -oyaml` to view configmap of gateway,
before fix:
<img width="886" alt="image" src="https://github.com/user-attachments/assets/8a92d2a7-f710-47a7-80ea-2b0efa005274" />
after fix:
<img width="525" alt="image" src="https://github.com/user-attachments/assets/4bb4be10-4560-495e-90cf-508e7d60258c" />
