### PR TITLE
feat: support setting resources for the ingress pod

### DIFF
--- a/charts/ingress-controller/Chart.yaml
+++ b/charts/ingress-controller/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - api7
   - crd
 type: application
-version: 0.1.7
+version: 0.1.8
 appVersion: 2.0.3
 sources:
   - https://github.com/api7/api7-helm-chart

--- a/charts/ingress-controller/README.md
+++ b/charts/ingress-controller/README.md
@@ -1,6 +1,6 @@
 # api7-ingress-controller
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.3](https://img.shields.io/badge/AppVersion-2.0.3-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.3](https://img.shields.io/badge/AppVersion-2.0.3-informational?style=flat-square)
 
 Ingress Controller for API7
 
@@ -38,6 +38,7 @@ Ingress Controller for API7
 | deployment.podAnnotations | object | `{}` |  |
 | deployment.podSecurityContext | object | `{}` |  |
 | deployment.replicas | int | `1` |  |
+| deployment.resources | object | `{}` | Set pod resource requests & limits |
 | deployment.tolerations | list | `[]` |  |
 | deployment.topologySpreadConstraints | list | `[]` |  |
 | fullnameOverride | string | `""` |  |

--- a/charts/ingress-controller/templates/deployment.yaml
+++ b/charts/ingress-controller/templates/deployment.yaml
@@ -55,12 +55,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 10m
-            memory: 64Mi
+          {{- toYaml .Values.deployment.resources | nindent 10 }}
         securityContext:
           {{- toYaml .Values.deployment.podSecurityContext | nindent 10 }}
       {{- with .Values.deployment.nodeSelector }}

--- a/charts/ingress-controller/values.yaml
+++ b/charts/ingress-controller/values.yaml
@@ -32,6 +32,8 @@ deployment:
     repository: api7/api7-ingress-controller
     pullPolicy: IfNotPresent
     tag: "2.0.3"
+  # -- Set pod resource requests & limits
+  resources: {}
 
 config:
   logLevel: "info"


### PR DESCRIPTION
It should use the default resource configuration of the k8s cluster and allow configuration.

Prevent the application from being unusable due to limit.