### PR TITLE
chore: upgrade version to 3.9.6

### DIFF
--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.45
+version: 0.17.46
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.9.5"
+appVersion: "3.9.6"
 
 maintainers:
   - name: API7

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -1,6 +1,6 @@
 # api7ee3
 
-![Version: 0.17.45](https://img.shields.io/badge/Version-0.17.45-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.5](https://img.shields.io/badge/AppVersion-3.9.5-informational?style=flat-square)
+![Version: 0.17.46](https://img.shields.io/badge/Version-0.17.46-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.6](https://img.shields.io/badge/AppVersion-3.9.6-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -28,7 +28,7 @@ A Helm chart for Kubernetes
 | dashboard.extraVolumes | list | `[]` |  |
 | dashboard.image.pullPolicy | string | `"Always"` |  |
 | dashboard.image.repository | string | `"api7/api7-ee-3-integrated"` |  |
-| dashboard.image.tag | string | `"v3.9.5"` |  |
+| dashboard.image.tag | string | `"v3.9.6"` |  |
 | dashboard.keyCertSecret | string | `""` |  |
 | dashboard.livenessProbe.failureThreshold | int | `30` |  |
 | dashboard.livenessProbe.initialDelaySeconds | int | `180` |  |
@@ -113,7 +113,7 @@ A Helm chart for Kubernetes
 | developer_portal.extraVolumes | list | `[]` |  |
 | developer_portal.image.pullPolicy | string | `"Always"` |  |
 | developer_portal.image.repository | string | `"api7/api7-ee-developer-portal"` |  |
-| developer_portal.image.tag | string | `"v3.9.5"` |  |
+| developer_portal.image.tag | string | `"v3.9.6"` |  |
 | developer_portal.keyCertSecret | string | `""` |  |
 | developer_portal.livenessProbe.failureThreshold | int | `10` |  |
 | developer_portal.livenessProbe.initialDelaySeconds | int | `60` |  |
@@ -158,7 +158,7 @@ A Helm chart for Kubernetes
 | dp_manager.extraVolumes | list | `[]` |  |
 | dp_manager.image.pullPolicy | string | `"Always"` |  |
 | dp_manager.image.repository | string | `"api7/api7-ee-dp-manager"` |  |
-| dp_manager.image.tag | string | `"v3.9.5"` |  |
+| dp_manager.image.tag | string | `"v3.9.6"` |  |
 | dp_manager.livenessProbe.failureThreshold | int | `10` |  |
 | dp_manager.livenessProbe.initialDelaySeconds | int | `60` |  |
 | dp_manager.livenessProbe.periodSeconds | int | `3` |  |

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -18,7 +18,7 @@ dashboard:
     repository: api7/api7-ee-3-integrated
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.5"
+    tag: "v3.9.6"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -54,7 +54,7 @@ dp_manager:
     repository: api7/api7-ee-dp-manager
     pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.5"
+    tag: "v3.9.6"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -92,7 +92,7 @@ developer_portal:
     repository: api7/api7-ee-developer-portal
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.5"
+    tag: "v3.9.6"
 
   extraEnvVars: []
   extraVolumes: []
@@ -332,7 +332,27 @@ dashboard_configuration:
     dsn: "postgres://api7ee:changeme@api7-postgresql:5432/api7ee"
     max_open_conns: 30
     max_idle_time: 30s
+    # max_lifetime: 60s
     timeout: 5s
+    # vault:
+    #   enabled: false
+    #   address: "http://vault:8200"
+    #   namespace: ""
+    #   base_dsn: "postgres://api7-postgresql:5432/api7ee?sslmode=disable" # no username/password
+    #   cred_cache_ttl: 30s
+    #   auth:
+    #     method: "token" # token | approle | kubernetes
+    #     token: ""
+    #     # role_id: ""
+    #     # secret_id: ""
+    #     # role: ""        # for kubernetes auth
+    #     # mount_path: ""  # optional auth mount path
+    #   database:
+    #     mount_path: "database"
+    #     role: "api7ee"
+    #   tls:
+    #     ca_cert: ""
+    #     insecure: false
   prometheus:
     addr: "http://api7-prometheus-server:9090"
     query_path_prefix: ""

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.55
+version: 0.2.56
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "3.9.5"
+appVersion: "3.9.6"
 
 maintainers:
   - name: API7

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -104,7 +104,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.httpRouter | string | `"radixtree_host_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
 | apisix.image.pullPolicy | string | `"Always"` | API7 Gateway image pull policy |
 | apisix.image.repository | string | `"api7/api7-ee-3-gateway"` | API7 Gateway image repository |
-| apisix.image.tag | string | `"3.9.5"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
+| apisix.image.tag | string | `"3.9.6"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
 | apisix.kind | string | `"Deployment"` | Use a `DaemonSet` or `Deployment` |
 | apisix.lru | object | `{"secret":{"count":512,"neg_count":512,"neg_ttl":60,"ttl":300}}` | fine tune the parameters of LRU cache for some features like secret |
 | apisix.lru.secret.neg_ttl | int | `60` | in seconds |

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -138,7 +138,7 @@ apisix:
     pullPolicy: Always
     # -- API7 Gateway image tag
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.9.5
+    tag: 3.9.6
 
   # -- Use a `DaemonSet` or `Deployment`
   kind: Deployment


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped chart versions for API7 and Gateway from 0.17.45/0.2.55 to 0.17.46/0.2.56 respectively.
  * Updated application version from 3.9.5 to 3.9.6 across all components.
  * Updated image tags to v3.9.6 for dashboard, developer portal, and dp-manager components.

* **Documentation**
  * Updated Helm chart README with new version and image tag examples.
  * Added new optional vault and max_lifetime configuration parameters (commented) for enhanced configuration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->