### PR TITLE
fix(api7): correct file-server image tag and pullPolicy

### DIFF
--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.49
+version: 0.17.50
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -1,6 +1,6 @@
 # api7ee3
 
-![Version: 0.17.49](https://img.shields.io/badge/Version-0.17.49-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.8](https://img.shields.io/badge/AppVersion-3.9.8-informational?style=flat-square)
+![Version: 0.17.50](https://img.shields.io/badge/Version-0.17.50-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.8](https://img.shields.io/badge/AppVersion-3.9.8-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -222,9 +222,9 @@ A Helm chart for Kubernetes
 | dp_manager_service.tlsPort | int | `7943` |  |
 | dp_manager_service.type | string | `"ClusterIP"` |  |
 | file_server.enabled | bool | `false` |  |
-| file_server.image.pullPolicy | string | `"IfNotPresent"` |  |
+| file_server.image.pullPolicy | string | `"Always"` |  |
 | file_server.image.repository | string | `"api7/api7-ee-file-server"` |  |
-| file_server.image.tag | string | `"dev"` |  |
+| file_server.image.tag | string | `"v3.9.8"` |  |
 | file_server.livenessProbe.failureThreshold | int | `10` |  |
 | file_server.livenessProbe.initialDelaySeconds | int | `60` |  |
 | file_server.livenessProbe.periodSeconds | int | `3` |  |

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -89,8 +89,8 @@ file_server:
   replicaCount: 1
   image:
     repository: api7/api7-ee-file-server
-    pullPolicy: IfNotPresent
-    tag: "dev"
+    pullPolicy: Always
+    tag: "v3.9.8"
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 3


### PR DESCRIPTION
## Changes

Fix file-server image configuration introduced in #274:

- `file_server.image.tag`: `dev` → `v3.9.8` (file-server is released with v3.9.8)
- `file_server.image.pullPolicy`: `IfNotPresent` → `Always` (consistent with dashboard, dp_manager, developer_portal)
- Bump api7 chart version: 0.17.49 → 0.17.50
- Regenerated README.md via helm-docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * File server container now uses an Always pull policy and is pinned to image version v3.9.8.
* **Documentation**
  * Defaults updated in the chart docs and the chart version badge bumped to 0.17.50 to reflect current configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->