### PR TITLE
feat(gateway): add optional openapi-to-mcp sidecar

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -231,6 +231,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | nginx.workerProcesses | string | `"auto"` |  |
 | nginx.workerRlimitNofile | string | `"20480"` |  |
 | nginx.workerShutdownTimeout | string | `"240s"` |  |
+| openapiToMcp.enabled | bool | `false` | Enable or disable the OpenAPI-to-MCP sidecar. Required when using the `openapi-to-mcp` or `mcp-tools-acl` plugins. The container runs alongside the gateway in the same pod and is reached on 127.0.0.1. |
+| openapiToMcp.image.pullPolicy | string | `"IfNotPresent"` | OpenAPI-to-MCP image pull policy |
+| openapiToMcp.image.repository | string | `"api7/openapi-to-mcp"` | OpenAPI-to-MCP image repository |
+| openapiToMcp.image.tag | string | `"0.0.1-beta"` | OpenAPI-to-MCP image tag |
+| openapiToMcp.port | int | `3000` | Port that the sidecar listens on. Must match the `port` configured under `plugin_attr.openapi-to-mcp` in the gateway config (defaults to 3000). |
+| openapiToMcp.resources | object | `{}` | Resources for the OpenAPI-to-MCP sidecar container. |
 | pluginAttrs | object | `{}` | Set APISIX plugin attributes, see [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L376) for more details |
 | rbac.create | bool | `false` |  |
 | serviceAccount.annotations | object | `{}` |  |

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -234,7 +234,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | openapiToMcp.enabled | bool | `false` | Enable or disable the OpenAPI-to-MCP sidecar. Required when using the `openapi-to-mcp` or `mcp-tools-acl` plugins. The container runs alongside the gateway in the same pod and is reached on 127.0.0.1. |
 | openapiToMcp.image.pullPolicy | string | `"IfNotPresent"` | OpenAPI-to-MCP image pull policy |
 | openapiToMcp.image.repository | string | `"api7/openapi-to-mcp"` | OpenAPI-to-MCP image repository |
-| openapiToMcp.image.tag | string | `"0.0.1-beta"` | OpenAPI-to-MCP image tag |
+| openapiToMcp.image.tag | string | `"1.0.0"` | OpenAPI-to-MCP image tag |
 | openapiToMcp.port | int | `3000` | Port that the sidecar listens on. Must match the `port` configured under `plugin_attr.openapi-to-mcp` in the gateway config (defaults to 3000). |
 | openapiToMcp.resources | object | `{}` | Resources for the OpenAPI-to-MCP sidecar container. |
 | pluginAttrs | object | `{}` | Set APISIX plugin attributes, see [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L376) for more details |

--- a/charts/gateway/templates/_pod.tpl
+++ b/charts/gateway/templates/_pod.tpl
@@ -230,8 +230,9 @@ spec:
     {{- end }}
     {{- if .Values.openapiToMcp.enabled }}
     {{- $mcpAttr := (index .Values.pluginAttrs "openapi-to-mcp" | default dict) -}}
-    {{- if and (hasKey $mcpAttr "port") (ne (int (index $mcpAttr "port")) (int .Values.openapiToMcp.port)) -}}
-    {{- fail (printf "openapiToMcp.port (%v) must match pluginAttrs.openapi-to-mcp.port (%v)" .Values.openapiToMcp.port (index $mcpAttr "port")) -}}
+    {{- $pluginMcpPort := (index $mcpAttr "port" | default 3000 | int) -}}
+    {{- if ne $pluginMcpPort (int .Values.openapiToMcp.port) -}}
+    {{- fail (printf "openapiToMcp.port (%v) must match pluginAttrs.openapi-to-mcp.port (%v; default 3000)" .Values.openapiToMcp.port $pluginMcpPort) -}}
     {{- end }}
     - name: openapi-to-mcp
       image: {{ .Values.openapiToMcp.image.repository }}:{{ .Values.openapiToMcp.image.tag }}

--- a/charts/gateway/templates/_pod.tpl
+++ b/charts/gateway/templates/_pod.tpl
@@ -229,6 +229,10 @@ spec:
           scheme: HTTP
     {{- end }}
     {{- if .Values.openapiToMcp.enabled }}
+    {{- $mcpAttr := (index .Values.pluginAttrs "openapi-to-mcp" | default dict) -}}
+    {{- if and (hasKey $mcpAttr "port") (ne (int (index $mcpAttr "port")) (int .Values.openapiToMcp.port)) -}}
+    {{- fail (printf "openapiToMcp.port (%v) must match pluginAttrs.openapi-to-mcp.port (%v)" .Values.openapiToMcp.port (index $mcpAttr "port")) -}}
+    {{- end }}
     - name: openapi-to-mcp
       image: {{ .Values.openapiToMcp.image.repository }}:{{ .Values.openapiToMcp.image.tag }}
       imagePullPolicy: {{ .Values.openapiToMcp.image.pullPolicy }}

--- a/charts/gateway/templates/_pod.tpl
+++ b/charts/gateway/templates/_pod.tpl
@@ -228,6 +228,49 @@ spec:
           port: http
           scheme: HTTP
     {{- end }}
+    {{- if .Values.openapiToMcp.enabled }}
+    - name: openapi-to-mcp
+      image: {{ .Values.openapiToMcp.image.repository }}:{{ .Values.openapiToMcp.image.tag }}
+      imagePullPolicy: {{ .Values.openapiToMcp.image.pullPolicy }}
+      env:
+      - name: SSE_PORT
+        value: {{ .Values.openapiToMcp.port | quote }}
+      ports:
+      - containerPort: {{ .Values.openapiToMcp.port }}
+        name: http
+        protocol: TCP
+      # The OpenAPI2MCP server binds to 127.0.0.1 inside the container, so
+      # httpGet / tcpSocket probes (which kubelet runs against the pod IP)
+      # cannot reach it. Use an exec probe via the bundled node binary.
+      readinessProbe:
+        failureThreshold: 6
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        successThreshold: 1
+        timeoutSeconds: 3
+        exec:
+          command:
+          - node
+          - -e
+          - |
+            const http = require('http');
+            http.get({host:'127.0.0.1',port:process.env.SSE_PORT||3000,path:'/health',timeout:2000}, r => process.exit(r.statusCode===200?0:1)).on('error', () => process.exit(1));
+      livenessProbe:
+        failureThreshold: 6
+        initialDelaySeconds: 10
+        periodSeconds: 10
+        successThreshold: 1
+        timeoutSeconds: 3
+        exec:
+          command:
+          - node
+          - -e
+          - |
+            const http = require('http');
+            http.get({host:'127.0.0.1',port:process.env.SSE_PORT||3000,path:'/health',timeout:2000}, r => process.exit(r.statusCode===200?0:1)).on('error', () => process.exit(1));
+      resources:
+      {{- toYaml .Values.openapiToMcp.resources | nindent 8 }}
+    {{- end }}
   {{- if .Values.apisix.hostNetwork }}
   hostNetwork: true
   dnsPolicy: ClusterFirstWithHostNet

--- a/charts/gateway/templates/_pod.tpl
+++ b/charts/gateway/templates/_pod.tpl
@@ -243,35 +243,24 @@ spec:
       - containerPort: {{ .Values.openapiToMcp.port }}
         name: http
         protocol: TCP
-      # The OpenAPI2MCP server binds to 127.0.0.1 inside the container, so
-      # httpGet / tcpSocket probes (which kubelet runs against the pod IP)
-      # cannot reach it. Use an exec probe via the bundled node binary.
       readinessProbe:
+        httpGet:
+          path: /health
+          port: {{ .Values.openapiToMcp.port }}
         failureThreshold: 6
         initialDelaySeconds: 5
         periodSeconds: 5
         successThreshold: 1
         timeoutSeconds: 3
-        exec:
-          command:
-          - node
-          - -e
-          - |
-            const http = require('http');
-            http.get({host:'127.0.0.1',port:process.env.SSE_PORT||3000,path:'/health',timeout:2000}, r => process.exit(r.statusCode===200?0:1)).on('error', () => process.exit(1));
       livenessProbe:
+        httpGet:
+          path: /health
+          port: {{ .Values.openapiToMcp.port }}
         failureThreshold: 6
         initialDelaySeconds: 10
         periodSeconds: 10
         successThreshold: 1
         timeoutSeconds: 3
-        exec:
-          command:
-          - node
-          - -e
-          - |
-            const http = require('http');
-            http.get({host:'127.0.0.1',port:process.env.SSE_PORT||3000,path:'/health',timeout:2000}, r => process.exit(r.statusCode===200?0:1)).on('error', () => process.exit(1));
       resources:
       {{- toYaml .Values.openapiToMcp.resources | nindent 8 }}
     {{- end }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -680,6 +680,24 @@ soapProxy:
     # -- SOAP proxy image pull policy
     pullPolicy: IfNotPresent
 
+openapiToMcp:
+  # -- Enable or disable the OpenAPI-to-MCP sidecar. Required when using the
+  # `openapi-to-mcp` or `mcp-tools-acl` plugins. The container runs alongside
+  # the gateway in the same pod and is reached on 127.0.0.1.
+  enabled: false
+  image:
+    # -- OpenAPI-to-MCP image repository
+    repository: api7/openapi-to-mcp
+    # -- OpenAPI-to-MCP image tag
+    tag: 0.0.1-beta
+    # -- OpenAPI-to-MCP image pull policy
+    pullPolicy: IfNotPresent
+  # -- Port that the sidecar listens on. Must match the `port` configured under
+  # `plugin_attr.openapi-to-mcp` in the gateway config (defaults to 3000).
+  port: 3000
+  # -- Resources for the OpenAPI-to-MCP sidecar container.
+  resources: {}
+
 control:
   # -- Enable Control API
   enabled: true

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -689,7 +689,7 @@ openapiToMcp:
     # -- OpenAPI-to-MCP image repository
     repository: api7/openapi-to-mcp
     # -- OpenAPI-to-MCP image tag
-    tag: 0.0.1-beta
+    tag: 1.0.0
     # -- OpenAPI-to-MCP image pull policy
     pullPolicy: IfNotPresent
   # -- Port that the sidecar listens on. Must match the `port` configured under


### PR DESCRIPTION
## Summary

The OpenAPI-to-MCP server has been extracted from the gateway image into a standalone image (`api7/openapi-to-mcp`). This PR adds an optional sidecar deployment for it under `openapiToMcp` in the gateway chart.

## Changes

- `charts/gateway/values.yaml`: new `openapiToMcp` block (`enabled: false`, image `api7/openapi-to-mcp:0.0.1-beta`, port 3000, empty `resources`).
- `charts/gateway/templates/_pod.tpl`: render the sidecar container when `openapiToMcp.enabled` is true. Shares the pod network namespace so the gateway plugin reaches it on `127.0.0.1:<port>`.
- `charts/gateway/README.md`: regenerated via `make helm-docs`.

## Notes

- The upstream server binds to `127.0.0.1` inside the container, so `httpGet`/`tcpSocket` probes from kubelet would fail. The template uses an `exec` probe that runs a small `node -e` script against `127.0.0.1:$SSE_PORT/health`.
- Default is `enabled: false`. Users running the `openapi-to-mcp` or `mcp-tools-acl` plugins must flip this to `true` after upgrading to a gateway image that no longer bundles the server.

## Related

- api7/OpenAPI2MCP#39 (standalone image + release workflow)
- api7/api7-ee-3-gateway#1463 (strip OpenAPI2MCP from gateway image)

## Verification

```
helm lint charts/gateway                    # passes
helm template t charts/gateway              # no openapi-to-mcp container
helm template t charts/gateway --set openapiToMcp.enabled=true   # container rendered
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional OpenAPI-to-MCP sidecar: enable/disable toggle, configurable image, port, and resource requests/limits.
  * Health checks (readiness & liveness) for the sidecar.
  * Deployment-time validation ensures sidecar port matches the gateway plugin port.

* **Documentation**
  * Helm chart values and README updated with sidecar configuration and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->