### PR TITLE
chore: upgrade api7 and gateway to v3.9.10

### DIFF
--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.51
+version: 0.17.52
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.9.9"
+appVersion: "3.9.10"
 
 maintainers:
   - name: API7

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -1,6 +1,6 @@
 # api7ee3
 
-![Version: 0.17.51](https://img.shields.io/badge/Version-0.17.51-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.9](https://img.shields.io/badge/AppVersion-3.9.9-informational?style=flat-square)
+![Version: 0.17.52](https://img.shields.io/badge/Version-0.17.52-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.10](https://img.shields.io/badge/AppVersion-3.9.10-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -28,7 +28,7 @@ A Helm chart for Kubernetes
 | dashboard.extraVolumes | list | `[]` |  |
 | dashboard.image.pullPolicy | string | `"Always"` |  |
 | dashboard.image.repository | string | `"api7/api7-ee-3-integrated"` |  |
-| dashboard.image.tag | string | `"v3.9.9"` |  |
+| dashboard.image.tag | string | `"v3.9.10"` |  |
 | dashboard.keyCertSecret | string | `""` |  |
 | dashboard.livenessProbe.failureThreshold | int | `30` |  |
 | dashboard.livenessProbe.initialDelaySeconds | int | `180` |  |
@@ -97,6 +97,11 @@ A Helm chart for Kubernetes
 | dashboard_configuration.session_options_config.max_age | int | `86400` |  |
 | dashboard_configuration.session_options_config.same_site | string | `"lax"` |  |
 | dashboard_configuration.session_options_config.secure | bool | `false` |  |
+| dashboard_configuration.telemetry.compression_level | int | `-1` |  |
+| dashboard_configuration.telemetry.enable | bool | `true` |  |
+| dashboard_configuration.telemetry.interval | int | `15` |  |
+| dashboard_configuration.telemetry.max_metrics_size | int | `33554432` |  |
+| dashboard_configuration.telemetry.metrics_batch_size | int | `4194304` |  |
 | dashboard_service.annotations | object | `{}` |  |
 | dashboard_service.ingress.annotations | object | `{}` |  |
 | dashboard_service.ingress.className | string | `""` |  |
@@ -113,7 +118,7 @@ A Helm chart for Kubernetes
 | developer_portal.extraVolumes | list | `[]` |  |
 | developer_portal.image.pullPolicy | string | `"Always"` |  |
 | developer_portal.image.repository | string | `"api7/api7-ee-developer-portal"` |  |
-| developer_portal.image.tag | string | `"v3.9.9"` |  |
+| developer_portal.image.tag | string | `"v3.9.10"` |  |
 | developer_portal.keyCertSecret | string | `""` |  |
 | developer_portal.livenessProbe.failureThreshold | int | `10` |  |
 | developer_portal.livenessProbe.initialDelaySeconds | int | `60` |  |
@@ -158,7 +163,7 @@ A Helm chart for Kubernetes
 | dp_manager.extraVolumes | list | `[]` |  |
 | dp_manager.image.pullPolicy | string | `"Always"` |  |
 | dp_manager.image.repository | string | `"api7/api7-ee-dp-manager"` |  |
-| dp_manager.image.tag | string | `"v3.9.9"` |  |
+| dp_manager.image.tag | string | `"v3.9.10"` |  |
 | dp_manager.livenessProbe.failureThreshold | int | `10` |  |
 | dp_manager.livenessProbe.initialDelaySeconds | int | `60` |  |
 | dp_manager.livenessProbe.periodSeconds | int | `3` |  |
@@ -224,7 +229,7 @@ A Helm chart for Kubernetes
 | file_server.enabled | bool | `false` |  |
 | file_server.image.pullPolicy | string | `"Always"` |  |
 | file_server.image.repository | string | `"api7/api7-ee-file-server"` |  |
-| file_server.image.tag | string | `"v3.9.9"` |  |
+| file_server.image.tag | string | `"v3.9.10"` |  |
 | file_server.livenessProbe.failureThreshold | int | `10` |  |
 | file_server.livenessProbe.initialDelaySeconds | int | `60` |  |
 | file_server.livenessProbe.periodSeconds | int | `3` |  |

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -18,7 +18,7 @@ dashboard:
     repository: api7/api7-ee-3-integrated
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.9"
+    tag: "v3.9.10"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -54,7 +54,7 @@ dp_manager:
     repository: api7/api7-ee-dp-manager
     pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.9"
+    tag: "v3.9.10"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -90,7 +90,7 @@ file_server:
   image:
     repository: api7/api7-ee-file-server
     pullPolicy: Always
-    tag: "v3.9.9"
+    tag: "v3.9.10"
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 3
@@ -108,7 +108,7 @@ developer_portal:
     repository: api7/api7-ee-developer-portal
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.9"
+    tag: "v3.9.10"
 
   extraEnvVars: []
   extraVolumes: []
@@ -415,6 +415,12 @@ dashboard_configuration:
     cache_success_ttl: 15
     cache_failure_count: 256
     cache_failure_ttl: 15
+  telemetry:
+    enable: true
+    interval: 15
+    max_metrics_size: 33554432
+    metrics_batch_size: 4194304
+    compression_level: -1
   # admin_api_address: "https://dash.api7.ai"
   # dp_manager_address:
   #   - "https://dpm.api7.ai"

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.60
+version: 0.2.61
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "3.9.9"
+appVersion: "3.9.10"
 
 maintainers:
   - name: API7

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -104,7 +104,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.httpRouter | string | `"radixtree_host_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
 | apisix.image.pullPolicy | string | `"Always"` | API7 Gateway image pull policy |
 | apisix.image.repository | string | `"api7/api7-ee-3-gateway"` | API7 Gateway image repository |
-| apisix.image.tag | string | `"3.9.9"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
+| apisix.image.tag | string | `"3.9.10"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
 | apisix.kind | string | `"Deployment"` | Use a `DaemonSet` or `Deployment` |
 | apisix.lru | object | `{"secret":{"count":512,"neg_count":512,"neg_ttl":60,"ttl":300}}` | fine tune the parameters of LRU cache for some features like secret |
 | apisix.lru.secret.neg_ttl | int | `60` | in seconds |

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -142,7 +142,7 @@ apisix:
     pullPolicy: Always
     # -- API7 Gateway image tag
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.9.9
+    tag: 3.9.10
 
   # -- Use a `DaemonSet` or `Deployment`
   kind: Deployment


### PR DESCRIPTION
## Changes

### Version bumps
- api7 chart: 0.17.51 → 0.17.52, appVersion 3.9.9 → 3.9.10
- gateway chart: 0.2.60 → 0.2.61, appVersion 3.9.9 → 3.9.10
- dashboard/dp_manager/developer_portal/file_server image tags: v3.9.9 → v3.9.10
- gateway image tag: 3.9.9 → 3.9.10

### Structural changes
- Added `telemetry` section to `dashboard_configuration` in api7 values.yaml (from CP helm PR — enables CP-managed telemetry config pushed to DP via heartbeat)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm charts to use application version 3.9.10 (API7 chart v0.17.52, Gateway chart v0.2.61)
  * Updated all container image tags to v3.9.10

* **New Features**
  * Added dashboard telemetry configuration options with customizable settings for interval, compression level, and metrics size

<!-- end of auto-generated comment: release notes by coderabbit.ai -->