### PR TITLE
chore: support specifying nodeport for the file-server service

### DIFF
--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.52
+version: 0.17.53
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -1,6 +1,6 @@
 # api7ee3
 
-![Version: 0.17.52](https://img.shields.io/badge/Version-0.17.52-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.10](https://img.shields.io/badge/AppVersion-3.9.10-informational?style=flat-square)
+![Version: 0.17.53](https://img.shields.io/badge/Version-0.17.53-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.10](https://img.shields.io/badge/AppVersion-3.9.10-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -241,7 +241,6 @@ A Helm chart for Kubernetes
 | file_server_configuration.file_server.listen | string | `"0.0.0.0:8080"` |  |
 | file_server_configuration.log.level | string | `"warn"` |  |
 | file_server_configuration.log.output | string | `"stderr"` |  |
-| file_server_service.nodePort | int | `nil` | The nodePort for HTTP service, only used if file_server_service.type is NodePort. If not set, a random port will be assigned by Kubernetes. |
 | file_server_service.port | int | `8080` |  |
 | file_server_service.type | string | `"ClusterIP"` |  |
 | fullnameOverride | string | `""` |  |

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -241,6 +241,7 @@ A Helm chart for Kubernetes
 | file_server_configuration.file_server.listen | string | `"0.0.0.0:8080"` |  |
 | file_server_configuration.log.level | string | `"warn"` |  |
 | file_server_configuration.log.output | string | `"stderr"` |  |
+| file_server_service.nodePort | int | `nil` | The nodePort for HTTP service, only used if file_server_service.type is NodePort. If not set, a random port will be assigned by Kubernetes. |
 | file_server_service.port | int | `8080` |  |
 | file_server_service.type | string | `"ClusterIP"` |  |
 | fullnameOverride | string | `""` |  |

--- a/charts/api7/templates/file-server-service.yaml
+++ b/charts/api7/templates/file-server-service.yaml
@@ -13,6 +13,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+      {{- if (and (eq .Values.file_server_service.type "NodePort") (not (empty .Values.file_server_service.nodePort))) }}
+      nodePort: {{ .Values.file_server_service.nodePort }}
+      {{- end }}
   selector:
     {{- include "api7ee3.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: file-server

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -217,6 +217,7 @@ dp_manager_service:
 file_server_service:
   type: ClusterIP
   port: 8080
+  # nodePort: 30080
 
 developer_portal_service:
   type: ClusterIP


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable nodePort for the file server service, available when service type is set to `NodePort`.

* **Chores**
  * Updated Helm chart version to 0.17.53.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->