### PR TITLE
chore(gateway): bump openapi-to-mcp image tag to 1.0.2

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.65
+version: 0.2.66
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -234,7 +234,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | openapiToMcp.enabled | bool | `false` | Enable or disable the OpenAPI-to-MCP sidecar. Required when using the `openapi-to-mcp` or `mcp-tools-acl` plugins. The container runs alongside the gateway in the same pod and is reached on 127.0.0.1. |
 | openapiToMcp.image.pullPolicy | string | `"IfNotPresent"` | OpenAPI-to-MCP image pull policy |
 | openapiToMcp.image.repository | string | `"api7/openapi-to-mcp"` | OpenAPI-to-MCP image repository |
-| openapiToMcp.image.tag | string | `"1.0.1"` | OpenAPI-to-MCP image tag |
+| openapiToMcp.image.tag | string | `"1.0.2"` | OpenAPI-to-MCP image tag |
 | openapiToMcp.port | int | `3000` | Port that the sidecar listens on. Must match the `port` configured under `plugin_attr.openapi-to-mcp` in the gateway config (defaults to 3000). |
 | openapiToMcp.resources | object | `{}` | Resources for the OpenAPI-to-MCP sidecar container. |
 | pluginAttrs | object | `{}` | Set APISIX plugin attributes, see [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L376) for more details |

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -689,7 +689,7 @@ openapiToMcp:
     # -- OpenAPI-to-MCP image repository
     repository: api7/openapi-to-mcp
     # -- OpenAPI-to-MCP image tag
-    tag: 1.0.1
+    tag: 1.0.2
     # -- OpenAPI-to-MCP image pull policy
     pullPolicy: IfNotPresent
   # -- Port that the sidecar listens on. Must match the `port` configured under


### PR DESCRIPTION
## Summary

Bump the OpenAPI-to-MCP sidecar image tag from `1.0.1` to `1.0.2`, and bump chart version from `0.2.65` to `0.2.66`.

## Changes

- `charts/gateway/values.yaml`: `openapiToMcp.image.tag` → `1.0.2`
- `charts/gateway/Chart.yaml`: `version` → `0.2.66`
- `charts/gateway/README.md`: regenerated with `helm-docs`

## References

- Release: https://github.com/api7/OpenAPI2MCP/releases/tag/v1.0.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped chart version to 0.2.66.
  * Updated the OpenAPI-to-MCP sidecar image to patch release 1.0.2 (was 1.0.1).
* **Documentation**
  * README updated to reflect the new default sidecar image tag.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/api7-helm-chart/pull/286)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->