### PR TITLE
feat(api7): add extraInitContainers support to dashboard and dp_manager deployments

### DIFF
--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.55
+version: 0.18.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -26,6 +26,7 @@ A Helm chart for Kubernetes
 | dashboard.extraEnvVars | list | `[]` |  |
 | dashboard.extraVolumeMounts | list | `[]` |  |
 | dashboard.extraVolumes | list | `[]` |  |
+| dashboard.extraInitContainers | list | `[]` |  |
 | dashboard.image.pullPolicy | string | `"Always"` |  |
 | dashboard.image.repository | string | `"api7/api7-ee-3-integrated"` |  |
 | dashboard.image.tag | string | `"v3.9.12"` |  |
@@ -116,6 +117,7 @@ A Helm chart for Kubernetes
 | developer_portal.extraEnvVars | list | `[]` |  |
 | developer_portal.extraVolumeMounts | list | `[]` |  |
 | developer_portal.extraVolumes | list | `[]` |  |
+| developer_portal.extraInitContainers | list | `[]` |  |
 | developer_portal.image.pullPolicy | string | `"Always"` |  |
 | developer_portal.image.repository | string | `"api7/api7-ee-developer-portal"` |  |
 | developer_portal.image.tag | string | `"v3.9.12"` |  |
@@ -161,6 +163,7 @@ A Helm chart for Kubernetes
 | dp_manager.extraEnvVars | list | `[]` |  |
 | dp_manager.extraVolumeMounts | list | `[]` |  |
 | dp_manager.extraVolumes | list | `[]` |  |
+| dp_manager.extraInitContainers | list | `[]` |  |
 | dp_manager.image.pullPolicy | string | `"Always"` |  |
 | dp_manager.image.repository | string | `"api7/api7-ee-dp-manager"` |  |
 | dp_manager.image.tag | string | `"v3.9.12"` |  |

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -1,6 +1,6 @@
 # api7ee3
 
-![Version: 0.17.55](https://img.shields.io/badge/Version-0.17.55-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.12](https://img.shields.io/badge/AppVersion-3.9.12-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.12](https://img.shields.io/badge/AppVersion-3.9.12-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -24,9 +24,9 @@ A Helm chart for Kubernetes
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | dashboard.extraEnvVars | list | `[]` |  |
+| dashboard.extraInitContainers | list | `[]` |  |
 | dashboard.extraVolumeMounts | list | `[]` |  |
 | dashboard.extraVolumes | list | `[]` |  |
-| dashboard.extraInitContainers | list | `[]` |  |
 | dashboard.image.pullPolicy | string | `"Always"` |  |
 | dashboard.image.repository | string | `"api7/api7-ee-3-integrated"` |  |
 | dashboard.image.tag | string | `"v3.9.12"` |  |
@@ -115,9 +115,9 @@ A Helm chart for Kubernetes
 | dashboard_service.tlsPort | int | `7443` |  |
 | dashboard_service.type | string | `"ClusterIP"` |  |
 | developer_portal.extraEnvVars | list | `[]` |  |
+| developer_portal.extraInitContainers | list | `[]` |  |
 | developer_portal.extraVolumeMounts | list | `[]` |  |
 | developer_portal.extraVolumes | list | `[]` |  |
-| developer_portal.extraInitContainers | list | `[]` |  |
 | developer_portal.image.pullPolicy | string | `"Always"` |  |
 | developer_portal.image.repository | string | `"api7/api7-ee-developer-portal"` |  |
 | developer_portal.image.tag | string | `"v3.9.12"` |  |
@@ -161,9 +161,9 @@ A Helm chart for Kubernetes
 | developer_portal_service.port | int | `4321` |  |
 | developer_portal_service.type | string | `"ClusterIP"` |  |
 | dp_manager.extraEnvVars | list | `[]` |  |
+| dp_manager.extraInitContainers | list | `[]` |  |
 | dp_manager.extraVolumeMounts | list | `[]` |  |
 | dp_manager.extraVolumes | list | `[]` |  |
-| dp_manager.extraInitContainers | list | `[]` |  |
 | dp_manager.image.pullPolicy | string | `"Always"` |  |
 | dp_manager.image.repository | string | `"api7/api7-ee-dp-manager"` |  |
 | dp_manager.image.tag | string | `"v3.9.12"` |  |

--- a/charts/api7/templates/dashboard-deploy.yaml
+++ b/charts/api7/templates/dashboard-deploy.yaml
@@ -51,6 +51,10 @@ spec:
           secret:
             secretName: {{ .Values.prometheus.server.existingSecret | quote }}
       {{- end }}
+      {{- if .Values.dashboard.extraInitContainers }}
+      initContainers:
+        {{- toYaml .Values.dashboard.extraInitContainers | nindent 8 }}
+      {{- end }}
       containers:
         - name: dashboard
           securityContext:

--- a/charts/api7/templates/dashboard-deploy.yaml
+++ b/charts/api7/templates/dashboard-deploy.yaml
@@ -53,7 +53,7 @@ spec:
       {{- end }}
       {{- if .Values.dashboard.extraInitContainers }}
       initContainers:
-        {{- toYaml .Values.dashboard.extraInitContainers | nindent 8 }}
+        {{- include "api7ee3.tplvalues.render" (dict "value" .Values.dashboard.extraInitContainers "context" $) | nindent 8 }}
       {{- end }}
       containers:
         - name: dashboard

--- a/charts/api7/templates/developer-portal-deploy.yaml
+++ b/charts/api7/templates/developer-portal-deploy.yaml
@@ -47,6 +47,10 @@ spec:
           secret:
             secretName: {{ .Values.developer_portal.keyCertSecret | quote }}
       {{- end }}
+      {{- if .Values.developer_portal.extraInitContainers }}
+      initContainers:
+        {{- toYaml .Values.developer_portal.extraInitContainers | nindent 8 }}
+      {{- end }}
       containers:
         - name: developer-portal
           securityContext:

--- a/charts/api7/templates/developer-portal-deploy.yaml
+++ b/charts/api7/templates/developer-portal-deploy.yaml
@@ -49,7 +49,7 @@ spec:
       {{- end }}
       {{- if .Values.developer_portal.extraInitContainers }}
       initContainers:
-        {{- toYaml .Values.developer_portal.extraInitContainers | nindent 8 }}
+        {{- include "api7ee3.tplvalues.render" (dict "value" .Values.developer_portal.extraInitContainers "context" $) | nindent 8 }}
       {{- end }}
       containers:
         - name: developer-portal

--- a/charts/api7/templates/dp-manager-deploy.yaml
+++ b/charts/api7/templates/dp-manager-deploy.yaml
@@ -46,6 +46,10 @@ spec:
       {{- if .Values.dashboard.extraVolumes }}
       {{- include "api7ee3.tplvalues.render" (dict "value" .Values.dashboard.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.dp_manager.extraInitContainers }}
+      initContainers:
+        {{- toYaml .Values.dp_manager.extraInitContainers | nindent 8 }}
+      {{- end }}
       containers:
         - name: dp-manager
           securityContext:

--- a/charts/api7/templates/dp-manager-deploy.yaml
+++ b/charts/api7/templates/dp-manager-deploy.yaml
@@ -43,8 +43,8 @@ spec:
           secret:
             secretName: {{ .Values.prometheus.server.existingSecret | quote }}
       {{- end }}
-      {{- if .Values.dashboard.extraVolumes }}
-      {{- include "api7ee3.tplvalues.render" (dict "value" .Values.dashboard.extraVolumes "context" $) | nindent 8 }}
+      {{- if .Values.dp_manager.extraVolumes }}
+      {{- include "api7ee3.tplvalues.render" (dict "value" .Values.dp_manager.extraVolumes "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.dp_manager.extraInitContainers }}
       initContainers:
@@ -89,8 +89,8 @@ spec:
               name: prometheus_ssl
               readOnly: true
           {{- end }}
-          {{- if .Values.dashboard.extraVolumeMounts }}
-          {{- include "api7ee3.tplvalues.render" (dict "value" .Values.dashboard.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- if .Values.dp_manager.extraVolumeMounts }}
+          {{- include "api7ee3.tplvalues.render" (dict "value" .Values.dp_manager.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
           resources:
             {{- if .Values.dp_manager.resources }}

--- a/charts/api7/templates/dp-manager-deploy.yaml
+++ b/charts/api7/templates/dp-manager-deploy.yaml
@@ -48,7 +48,7 @@ spec:
       {{- end }}
       {{- if .Values.dp_manager.extraInitContainers }}
       initContainers:
-        {{- toYaml .Values.dp_manager.extraInitContainers | nindent 8 }}
+        {{- include "api7ee3.tplvalues.render" (dict "value" .Values.dp_manager.extraInitContainers "context" $) | nindent 8 }}
       {{- end }}
       containers:
         - name: dp-manager

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -34,6 +34,7 @@ dashboard:
   extraEnvVars: []
   extraVolumes: []
   extraVolumeMounts: []
+  extraInitContainers: []
   podLabels: {}
   # -- Topology Spread Constraints for pod assignment
   # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
@@ -70,6 +71,7 @@ dp_manager:
   extraEnvVars: []
   extraVolumes: []
   extraVolumeMounts: []
+  extraInitContainers: []
   podLabels: {}
   # -- Topology Spread Constraints for pod assignment
   # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
@@ -113,6 +115,7 @@ developer_portal:
   extraEnvVars: []
   extraVolumes: []
   extraVolumeMounts: []
+  extraInitContainers: []
   podLabels: {}
   # -- Topology Spread Constraints for pod assignment
   # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/


### PR DESCRIPTION
### PR Overview

The _charts/api7_ chart currently exposes **extraEnvVars, extraVolumes, and extraVolumeMounts** on the _dashboard, developer_portal and dp_manager_ components, but no **extraInitContainers**. This makes it impossible to run initialization logic before the main container starts. For example, setup and ssl certificates required for connections, setup custom agents within the pods, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configurable custom init containers for dashboard, developer-portal, and dp-manager via Helm values.

* **Documentation**
  * Added documentation for the new extraInitContainers values and their defaults in the chart README/values.

* **Chores**
  * Bumped chart version to publish the update.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/api7-helm-chart/pull/287)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->