### PR TITLE
feat: expose S3 custom endpoint for fallback CP

### DIFF
--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.18.0
+version: 0.18.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -1,6 +1,6 @@
 # api7ee3
 
-![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.12](https://img.shields.io/badge/AppVersion-3.9.12-informational?style=flat-square)
+![Version: 0.18.1](https://img.shields.io/badge/Version-0.18.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.12](https://img.shields.io/badge/AppVersion-3.9.12-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -436,6 +436,8 @@ dashboard_configuration:
   #     region: "ap-south-1"
   #     resource_bucket: "to-push-resource-data"
   #     config_bucket: "to-push-config-data"
+  #     # optional, set to use an S3-compatible endpoint (e.g., MinIO, Ceph, Aliyun OSS)
+  #     custom_endpoint: ""
   #   azure_blob:
   #     account_name: "$YOUR_ACCOUNT_NAME"
   #     account_key: "$YOUR_ACCOUNT_KEY"

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.66
+version: 0.2.67
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -262,6 +262,8 @@ deployment:
   #    region: "ap-south-1"
   #    resource_bucket: "to-push-resource-data"
   #    config_bucket: "to-push-config-data"
+  #    # optional, set to use an S3-compatible endpoint (e.g., MinIO, Ceph, Aliyun OSS)
+  #    endpoint: ""
   #  # azure blob storage configuration, when account key is not set, will use the Managed Identity attached to the pod
   #  azure_blob:
   #    account_name: "$YOUR_ACCOUNT_NAME"


### PR DESCRIPTION
The Fallback CP feature already supports connecting to S3-compatible storage (MinIO, Ceph, Aliyun OSS, etc.) in both the gateway and dashboard code. However, the `endpoint`/`custom_endpoint` fields were missing from the helm charts' `values.yaml`, making them undiscoverable for users.

This PR exposes the endpoint configuration in both charts:

**Gateway chart** (`charts/gateway`):
- Add `endpoint` field to `deployment.fallback_cp.aws_s3` comments
- Bump version: 0.2.66 → 0.2.67

**API7 chart** (`charts/api7`):
- Add `custom_endpoint` field to `fallback_cp.aws_s3` comments
- Bump version: 0.18.0 → 0.18.1

Note: the field name differs between components — gateway uses `endpoint` (matching `lua-resty-aws-s3` FFI signature) while dashboard uses `custom_endpoint` (Go `mapstructure` tag in `s3_store.go`). Both map to AWS SDK v2's `BaseEndpoint`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional S3-compatible endpoint configuration for the fallback control plane.
  * Documented optional S3-compatible endpoint for the dashboard configuration (commented).

* **Chores**
  * Bumped chart versions: gateway to 0.2.67 and api7 to 0.18.1.

* **Documentation**
  * Updated chart README badge to reflect new api7 version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/api7-helm-chart/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->