### PR TITLE
chore: upgrade api7 and gateway to v3.9.13

### DIFF
--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.18.1
+version: 0.18.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.9.12"
+appVersion: "3.9.13"
 
 maintainers:
   - name: API7

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -1,6 +1,6 @@
 # api7ee3
 
-![Version: 0.18.1](https://img.shields.io/badge/Version-0.18.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.12](https://img.shields.io/badge/AppVersion-3.9.12-informational?style=flat-square)
+![Version: 0.18.2](https://img.shields.io/badge/Version-0.18.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.13](https://img.shields.io/badge/AppVersion-3.9.13-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -29,7 +29,7 @@ A Helm chart for Kubernetes
 | dashboard.extraVolumes | list | `[]` |  |
 | dashboard.image.pullPolicy | string | `"Always"` |  |
 | dashboard.image.repository | string | `"api7/api7-ee-3-integrated"` |  |
-| dashboard.image.tag | string | `"v3.9.12"` |  |
+| dashboard.image.tag | string | `"v3.9.13"` |  |
 | dashboard.keyCertSecret | string | `""` |  |
 | dashboard.livenessProbe.failureThreshold | int | `30` |  |
 | dashboard.livenessProbe.initialDelaySeconds | int | `180` |  |
@@ -120,7 +120,7 @@ A Helm chart for Kubernetes
 | developer_portal.extraVolumes | list | `[]` |  |
 | developer_portal.image.pullPolicy | string | `"Always"` |  |
 | developer_portal.image.repository | string | `"api7/api7-ee-developer-portal"` |  |
-| developer_portal.image.tag | string | `"v3.9.12"` |  |
+| developer_portal.image.tag | string | `"v3.9.13"` |  |
 | developer_portal.keyCertSecret | string | `""` |  |
 | developer_portal.livenessProbe.failureThreshold | int | `10` |  |
 | developer_portal.livenessProbe.initialDelaySeconds | int | `60` |  |
@@ -166,7 +166,7 @@ A Helm chart for Kubernetes
 | dp_manager.extraVolumes | list | `[]` |  |
 | dp_manager.image.pullPolicy | string | `"Always"` |  |
 | dp_manager.image.repository | string | `"api7/api7-ee-dp-manager"` |  |
-| dp_manager.image.tag | string | `"v3.9.12"` |  |
+| dp_manager.image.tag | string | `"v3.9.13"` |  |
 | dp_manager.livenessProbe.failureThreshold | int | `10` |  |
 | dp_manager.livenessProbe.initialDelaySeconds | int | `60` |  |
 | dp_manager.livenessProbe.periodSeconds | int | `3` |  |
@@ -232,7 +232,7 @@ A Helm chart for Kubernetes
 | file_server.enabled | bool | `false` |  |
 | file_server.image.pullPolicy | string | `"Always"` |  |
 | file_server.image.repository | string | `"api7/api7-ee-file-server"` |  |
-| file_server.image.tag | string | `"v3.9.12"` |  |
+| file_server.image.tag | string | `"v3.9.13"` |  |
 | file_server.livenessProbe.failureThreshold | int | `10` |  |
 | file_server.livenessProbe.initialDelaySeconds | int | `60` |  |
 | file_server.livenessProbe.periodSeconds | int | `3` |  |

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -18,7 +18,7 @@ dashboard:
     repository: api7/api7-ee-3-integrated
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.12"
+    tag: "v3.9.13"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -55,7 +55,7 @@ dp_manager:
     repository: api7/api7-ee-dp-manager
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.12"
+    tag: "v3.9.13"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -92,7 +92,7 @@ file_server:
   image:
     repository: api7/api7-ee-file-server
     pullPolicy: Always
-    tag: "v3.9.12"
+    tag: "v3.9.13"
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 3
@@ -110,7 +110,7 @@ developer_portal:
     repository: api7/api7-ee-developer-portal
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.12"
+    tag: "v3.9.13"
 
   extraEnvVars: []
   extraVolumes: []
@@ -438,6 +438,7 @@ dashboard_configuration:
   #     config_bucket: "to-push-config-data"
   #     # optional, set to use an S3-compatible endpoint (e.g., MinIO, Ceph, Aliyun OSS)
   #     custom_endpoint: ""
+  #     use_path_style: true
   #   azure_blob:
   #     account_name: "$YOUR_ACCOUNT_NAME"
   #     account_key: "$YOUR_ACCOUNT_KEY"

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.67
+version: 0.2.68
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "3.9.12"
+appVersion: "3.9.13"
 
 maintainers:
   - name: API7

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -82,7 +82,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.http.luaSharedDict.cas-auth | string | `"10m"` |  |
 | apisix.http.luaSharedDict.discovery | string | `"1m"` |  |
 | apisix.http.luaSharedDict.etcd-cluster-health-check | string | `"10m"` |  |
-| apisix.http.luaSharedDict.ext-plugin | string | `"1m"` |  |
 | apisix.http.luaSharedDict.internal-status | string | `"10m"` |  |
 | apisix.http.luaSharedDict.introspection | string | `"10m"` |  |
 | apisix.http.luaSharedDict.jwks | string | `"1m"` |  |
@@ -104,7 +103,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.httpRouter | string | `"radixtree_host_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
 | apisix.image.pullPolicy | string | `"Always"` | API7 Gateway image pull policy |
 | apisix.image.repository | string | `"api7/api7-ee-3-gateway"` | API7 Gateway image repository |
-| apisix.image.tag | string | `"3.9.12"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
+| apisix.image.tag | string | `"3.9.13"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
 | apisix.kind | string | `"Deployment"` | Use a `DaemonSet` or `Deployment` |
 | apisix.lru | object | `{"secret":{"count":512,"neg_count":512,"neg_ttl":60,"ttl":300}}` | fine tune the parameters of LRU cache for some features like secret |
 | apisix.lru.secret.neg_ttl | int | `60` | in seconds |

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -120,6 +120,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.podSecurityContext | object | `{}` | Set the securityContext for API7 Gateway pods |
 | apisix.priorityClassName | string | `""` | Set [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for API7 Gateway pods |
 | apisix.replicaCount | int | `1` | kind is DaemonSet, replicaCount not become effective |
+| apisix.requestBodyJsonLib | string | `"simdjson"` | JSON library used to decode request bodies parsed by core.request. Also controls AI upstream request body encoding. Allowed values: `cjson`, `simdjson`, `qjson`. |
 | apisix.resources | object | `{}` | Set pod resource requests & limits |
 | apisix.securityContext | object | `{}` | Set the securityContext for API7 Gateway container |
 | apisix.setIDFromPodUID | bool | `false` | Use Pod metadata.uid as the APISIX id. |

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -36,6 +36,7 @@ data:
       {{- if .Values.apisix.extraLuaCPath }}
       extra_lua_cpath: "{{ .Values.apisix.extraLuaCPath }};"
       {{- end }}
+      request_body_json_lib: {{ .Values.apisix.requestBodyJsonLib }}
 
       enable_dev_mode: false                       # Sets nginx worker_processes to 1 if set to true
       enable_reuseport: true                       # Enable nginx SO_REUSEPORT switch if set to true.

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -114,6 +114,8 @@ apisix:
 
   extraLuaPath: ""
   extraLuaCPath: ""
+  # -- JSON library used to decode request bodies parsed by core.request. Also controls AI upstream request body encoding. Allowed values: `cjson`, `simdjson`, `qjson`.
+  requestBodyJsonLib: simdjson
 
   # -- Delete the '/' at the end of the URI
   deleteURITailSlash: false

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -265,6 +265,7 @@ deployment:
   #    config_bucket: "to-push-config-data"
   #    # optional, set to use an S3-compatible endpoint (e.g., MinIO, Ceph, Aliyun OSS)
   #    endpoint: ""
+  #    use_path_style: true
   #  # azure blob storage configuration, when account key is not set, will use the Managed Identity attached to the pod
   #  azure_blob:
   #    account_name: "$YOUR_ACCOUNT_NAME"

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -82,7 +82,6 @@ apisix:
       jwks: 1m
       introspection: 10m
       access-tokens: 1m
-      ext-plugin: 1m
       tars: 1m
       cas-auth: 10m
       status_report: 1m
@@ -142,7 +141,7 @@ apisix:
     pullPolicy: Always
     # -- API7 Gateway image tag
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.9.12
+    tag: 3.9.13
 
   # -- Use a `DaemonSet` or `Deployment`
   kind: Deployment


### PR DESCRIPTION
Updates the API7 and gateway Helm charts for API7 Enterprise v3.9.13.

Changes:
* Bumps api7ee3 chart to 0.18.2 and appVersion to 3.9.13.
* Updates API7 component image tags to v3.9.13.
* Bumps gateway chart to 0.2.68 and appVersion/image tag to 3.9.13.
* Exposes the gateway `apisix.requestBodyJsonLib` value and renders it as `request_body_json_lib` in config.yaml.
* Adds fallback CP S3 path-style example options for API7 and gateway values.
* Removes the deprecated ext-plugin shared dict from gateway values.
* Regenerates chart README files.