### PR TITLE
chore: bump api7-ingress-controller to 2.1.0

### DIFF
--- a/charts/ingress-controller/Chart.yaml
+++ b/charts/ingress-controller/Chart.yaml
@@ -6,8 +6,8 @@ keywords:
   - api7
   - crd
 type: application
-version: 0.1.23
-appVersion: 2.0.16
+version: 0.1.24
+appVersion: 2.1.0
 maintainers:
   - name: API7
     email: support@api7.ai

--- a/charts/ingress-controller/README.md
+++ b/charts/ingress-controller/README.md
@@ -1,6 +1,6 @@
 # api7-ingress-controller
 
-![Version: 0.1.23](https://img.shields.io/badge/Version-0.1.23-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.16](https://img.shields.io/badge/AppVersion-2.0.16-informational?style=flat-square)
+![Version: 0.1.24](https://img.shields.io/badge/Version-0.1.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 Ingress Controller for API7
 
@@ -20,7 +20,7 @@ Ingress Controller for API7
 |-----|------|---------|-------------|
 | adc.image.pullPolicy | string | `"IfNotPresent"` |  |
 | adc.image.repository | string | `"ghcr.io/api7/adc"` |  |
-| adc.image.tag | string | `"0.23.1"` |  |
+| adc.image.tag | string | `"0.26.0"` |  |
 | adc.logLevel | string | `"info"` |  |
 | adc.resources | object | `{}` |  |
 | adc.securityContext | object | `{}` |  |
@@ -48,7 +48,7 @@ Ingress Controller for API7
 | deployment.annotations | object | `{}` |  |
 | deployment.image.pullPolicy | string | `"IfNotPresent"` |  |
 | deployment.image.repository | string | `"api7/api7-ingress-controller"` |  |
-| deployment.image.tag | string | `"2.0.16"` |  |
+| deployment.image.tag | string | `"2.1.0"` |  |
 | deployment.nodeSelector | object | `{}` |  |
 | deployment.podAnnotations | object | `{}` |  |
 | deployment.podSecurityContext.fsGroup | int | `2000` |  |

--- a/charts/ingress-controller/crds/apisix-crds.yaml
+++ b/charts/ingress-controller/crds/apisix-crds.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/charts/ingress-controller/crds/apisix-crds.yaml
+++ b/charts/ingress-controller/crds/apisix-crds.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -97,13 +98,6 @@ spec:
                         x-kubernetes-map-type: atomic
                       value:
                         description: Value specifies HMAC authentication credentials.
-                        oneOf:
-                        - required:
-                          - key_id
-                          - secret_key
-                        - required:
-                          - access_key
-                          - secret_key
                         properties:
                           access_key:
                             description: AccessKey is the identifier used to look
@@ -183,7 +177,6 @@ spec:
                             description: |-
                               Algorithm specifies the signing algorithm.
                               Can be `HS256`, `HS384`, `HS512`, `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`, `PS256`, `PS384`, `PS512`, or `EdDSA`.
-                              Currently APISIX only supports `HS256`, `HS512`, `RS256`, and `ES256`. API7 Enterprise supports all algorithms.
                             type: string
                           base64_secret:
                             description: Base64Secret indicates whether the secret
@@ -216,8 +209,15 @@ spec:
                             type: string
                         required:
                         - key
-                        - private_key
                         type: object
+                        x-kubernetes-validations:
+                        - message: algorithms other than HS256/HS384/HS512 require
+                            at least one non-empty public_key or private_key
+                          rule: '!has(self.algorithm) || size(self.algorithm) == 0
+                            || self.algorithm in [''HS256'',''HS384'',''HS512''] ||
+                            (has(self.public_key) && size(self.public_key.trim())
+                            > 0) || (has(self.private_key) && size(self.private_key.trim())
+                            > 0)'
                     type: object
                   keyAuth:
                     description: KeyAuth configures the key authentication details.
@@ -319,8 +319,32 @@ spec:
                   IngressClassName is the name of an IngressClass cluster resource.
                   The controller uses this field to decide whether the resource should be managed.
                 type: string
-            required:
-            - authParameter
+              plugins:
+                description: |-
+                  Plugins lists additional consumer-scoped plugins to attach to this consumer.
+                  These plugins are applied alongside any authentication plugin derived from AuthParameter.
+                  An enabled plugin with the same name as the auth plugin derived from AuthParameter takes precedence.
+                items:
+                  description: ApisixRoutePlugin represents an APISIX plugin.
+                  properties:
+                    config:
+                      description: Plugin configuration.
+                      x-kubernetes-preserve-unknown-fields: true
+                    enable:
+                      default: true
+                      description: Whether this plugin is in use, default is true.
+                      type: boolean
+                    name:
+                      description: The plugin name.
+                      type: string
+                    secretRef:
+                      description: Plugin configuration secretRef.
+                      type: string
+                  required:
+                  - enable
+                  - name
+                  type: object
+                type: array
             type: object
           status:
             description: ApisixStatus is the status report for Apisix ingress Resources
@@ -387,6 +411,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -526,6 +551,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -667,6 +693,7 @@ spec:
     subresources:
       status: {}
 ---
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -715,7 +742,7 @@ spec:
     name: v2
     schema:
       openAPIV3Schema:
-        description: ApisixRoute is defines configuration for HTTP and stream routes.
+        description: ApisixRoute defines configuration for HTTP and stream routes.
         properties:
           apiVersion:
             description: |-
@@ -871,21 +898,37 @@ spec:
                               subject:
                                 description: |-
                                   Subject defines the left-hand side of the expression.
-                                  It can be any [built-in variable](/apisix/reference/built-in-variables) or string literal.
+                                  It can be any [APISIX variable](https://apisix.apache.org/docs/apisix/apisix-variable) or string literal.
                                 properties:
                                   name:
-                                    description: Name is the name of the header or
-                                      query parameter.
+                                    description: |-
+                                      Name is the name of the subject within the given scope: the header name, query
+                                      parameter name, cookie name, Nginx variable name, or body field name (dot-notation
+                                      JSON path supported for Body scope). Optional when Scope is Path.
                                     type: string
                                   scope:
                                     description: |-
-                                      Scope specifies the subject scope and can be `Header`, `Query`, or `Path`.
+                                      Scope specifies the subject scope.
+                                      Supported values: `Header`, `Query`, `Path`, `Cookie`, `Variable`, `Body`.
                                       When Scope is `Path`, Name will be ignored.
+                                      When Scope is `Body`, Name supports dot-notation JSON path (e.g., "model.version",
+                                      "messages[*].role") and maps to APISIX's `post_arg.<name>` variable, which works with
+                                      application/json, application/x-www-form-urlencoded, and multipart/form-data.
+                                    enum:
+                                    - Header
+                                    - Query
+                                    - Path
+                                    - Cookie
+                                    - Variable
+                                    - Body
                                     type: string
                                 required:
-                                - name
                                 - scope
                                 type: object
+                                x-kubernetes-validations:
+                                - message: name is required when scope is not Path
+                                  rule: self.scope == 'Path' || size(self.name) >
+                                    0
                               value:
                                 description: |-
                                   Value defines a single value to compare against the subject.
@@ -901,7 +944,6 @@ spec:
                           description: |-
                             FilterFunc is a user-defined function for advanced request filtering.
                             The function can use Nginx variables through the `vars` parameter.
-                            This field is supported in APISIX but not in API7 Enterprise.
                           type: string
                         hosts:
                           description: |-
@@ -1029,7 +1071,7 @@ spec:
                   Each rule specifies conditions to match TCP/UDP traffic and how to forward them.
                 items:
                   description: ApisixRouteStream defines the configuration for a Layer
-                    4 (TCP/UDP) route. Currently not supported.
+                    4 (TCP/UDP) route.
                   properties:
                     backend:
                       description: Backend specifies the destination service to which
@@ -1200,6 +1242,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1395,6 +1438,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2199,6 +2243,7 @@ spec:
     subresources:
       status: {}
 ---
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2242,6 +2287,181 @@ spec:
               BackendTrafficPolicySpec defines traffic handling policies applied to backend services,
               such as load balancing strategy, connection settings, and failover behavior.
             properties:
+              healthCheck:
+                description: |-
+                  HealthCheck defines active and passive health check configuration for
+                  the upstream backends. When configured, APISIX will probe backends
+                  (active) or monitor live traffic (passive) to detect and bypass
+                  unhealthy nodes.
+                properties:
+                  active:
+                    description: Active health checks proactively send requests to
+                      upstream nodes to determine their availability.
+                    properties:
+                      concurrency:
+                        description: Concurrency sets the number of targets to be
+                          checked at the same time.
+                        minimum: 0
+                        type: integer
+                      healthy:
+                        description: Healthy configures the thresholds for marking
+                          a node healthy.
+                        properties:
+                          httpCodes:
+                            description: HTTPCodes is the list of HTTP status codes
+                              considered healthy.
+                            items:
+                              type: integer
+                            minItems: 1
+                            type: array
+                          interval:
+                            description: |-
+                              Interval defines the time between health check probes.
+                              Minimum is 1s.
+                            type: string
+                          successes:
+                            description: Successes is the number of consecutive successful
+                              responses required to mark a node healthy.
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                      host:
+                        description: Host sets the upstream host used in the health
+                          check request.
+                        type: string
+                      httpPath:
+                        description: HTTPPath sets the HTTP path for the probe request.
+                        type: string
+                      port:
+                        description: Port sets the port on the upstream node to probe.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      requestHeaders:
+                        description: RequestHeaders sets additional HTTP request headers
+                          for the probe.
+                        items:
+                          type: string
+                        type: array
+                      strictTLS:
+                        description: StrictTLS controls whether TLS certificate validation
+                          is enforced.
+                        type: boolean
+                      timeout:
+                        description: Timeout sets health check timeout.
+                        type: string
+                      type:
+                        default: http
+                        description: Type is the health check type. Can be `http`,
+                          `https`, or `tcp`.
+                        enum:
+                        - http
+                        - https
+                        - tcp
+                        type: string
+                      unhealthy:
+                        description: Unhealthy configures the thresholds for marking
+                          a node unhealthy.
+                        properties:
+                          httpCodes:
+                            description: HTTPCodes is the list of HTTP status codes
+                              considered unhealthy.
+                            items:
+                              type: integer
+                            minItems: 1
+                            type: array
+                          httpFailures:
+                            description: HTTPFailures is the number of HTTP failures
+                              to mark a node unhealthy.
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                          interval:
+                            description: |-
+                              Interval defines the time between health check probes.
+                              Minimum is 1s.
+                            type: string
+                          tcpFailures:
+                            description: TCPFailures is the number of TCP failures
+                              to mark a node unhealthy.
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                          timeouts:
+                            description: Timeouts is the number of timeouts to mark
+                              a node unhealthy.
+                            maximum: 254
+                            minimum: 1
+                            type: integer
+                        type: object
+                    type: object
+                  passive:
+                    description: Passive health checks evaluate upstream health based
+                      on observed traffic (timeouts, errors).
+                    properties:
+                      healthy:
+                        description: Healthy defines conditions under which a node
+                          is considered healthy.
+                        properties:
+                          httpCodes:
+                            description: HTTPCodes is the list of HTTP status codes
+                              considered healthy.
+                            items:
+                              type: integer
+                            minItems: 1
+                            type: array
+                          successes:
+                            description: Successes is the number of consecutive successful
+                              responses required to mark a node healthy.
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                        type: object
+                      type:
+                        default: http
+                        description: Type is the passive health check type. Can be
+                          `http`, `https`, or `tcp`.
+                        enum:
+                        - http
+                        - https
+                        - tcp
+                        type: string
+                      unhealthy:
+                        description: Unhealthy defines conditions under which a node
+                          is considered unhealthy.
+                        properties:
+                          httpCodes:
+                            description: HTTPCodes is the list of HTTP status codes
+                              considered unhealthy.
+                            items:
+                              type: integer
+                            minItems: 1
+                            type: array
+                          httpFailures:
+                            description: HTTPFailures is the number of HTTP failures
+                              to mark a node unhealthy.
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                          tcpFailures:
+                            description: TCPFailures is the number of TCP failures
+                              to mark a node unhealthy.
+                            maximum: 254
+                            minimum: 0
+                            type: integer
+                          timeouts:
+                            description: Timeouts is the number of timeouts to mark
+                              a node unhealthy.
+                            maximum: 254
+                            minimum: 1
+                            type: integer
+                        type: object
+                    type: object
+                required:
+                - active
+                type: object
               loadbalancer:
                 description: |-
                   LoadBalancer represents the load balancer configuration for Kubernetes Service.
@@ -2712,6 +2932,7 @@ spec:
     subresources:
       status: {}
 ---
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2757,11 +2978,6 @@ spec:
               credentials:
                 description: Credentials specifies the credential details of a consumer.
                 items:
-                  oneOf:
-                  - required:
-                    - config
-                  - required:
-                    - secretRef
                   properties:
                     config:
                       description: Config specifies the credential details for authentication.
@@ -2899,6 +3115,7 @@ spec:
     subresources:
       status: {}
 ---
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -3027,6 +3244,11 @@ spec:
                           type: string
                         minItems: 1
                         type: array
+                      mode:
+                        description: |-
+                          Mode specifies the mode of control plane provider.
+                          Can be `apisix` or `apisix-standalone`.
+                        type: string
                       service:
                         properties:
                           name:
@@ -3050,6 +3272,9 @@ spec:
                     type: object
                     x-kubernetes-validations:
                     - rule: has(self.endpoints) != has(self.service)
+                    - message: mode is immutable
+                      rule: oldSelf == null || (!has(self.mode) && !has(oldSelf.mode))
+                        || self.mode == oldSelf.mode
                   type:
                     description: Type specifies the type of provider. Can only be
                       `ControlPlane`.
@@ -3081,6 +3306,7 @@ spec:
         type: object
     served: true
     storage: true
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3497,6 +3723,7 @@ spec:
     storage: true
     subresources:
       status: {}
+---
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/ingress-controller/crds/apisix-crds.yaml
+++ b/charts/ingress-controller/crds/apisix-crds.yaml
@@ -97,6 +97,13 @@ spec:
                         x-kubernetes-map-type: atomic
                       value:
                         description: Value specifies HMAC authentication credentials.
+                        oneOf:
+                        - required:
+                          - key_id
+                          - secret_key
+                        - required:
+                          - access_key
+                          - secret_key
                         properties:
                           access_key:
                             description: AccessKey is the identifier used to look
@@ -2970,6 +2977,11 @@ spec:
               credentials:
                 description: Credentials specifies the credential details of a consumer.
                 items:
+                  oneOf:
+                  - required:
+                    - config
+                  - required:
+                    - secretRef
                   properties:
                     config:
                       description: Config specifies the credential details for authentication.

--- a/charts/ingress-controller/crds/apisix-crds.yaml
+++ b/charts/ingress-controller/crds/apisix-crds.yaml
@@ -412,7 +412,6 @@ spec:
     subresources:
       status: {}
 ---
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -551,7 +550,6 @@ spec:
     storage: true
     subresources:
       status: {}
----
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -692,7 +690,6 @@ spec:
     storage: true
     subresources:
       status: {}
----
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1243,7 +1240,6 @@ spec:
     subresources:
       status: {}
 ---
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -1438,7 +1434,6 @@ spec:
     storage: true
     subresources:
       status: {}
----
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2243,7 +2238,6 @@ spec:
     subresources:
       status: {}
 ---
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2932,7 +2926,6 @@ spec:
     subresources:
       status: {}
 ---
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -3114,7 +3107,6 @@ spec:
     storage: true
     subresources:
       status: {}
----
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3306,7 +3298,6 @@ spec:
         type: object
     served: true
     storage: true
----
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -3723,7 +3714,6 @@ spec:
     storage: true
     subresources:
       status: {}
----
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/ingress-controller/values.yaml
+++ b/charts/ingress-controller/values.yaml
@@ -34,14 +34,14 @@ deployment:
   image:
     repository: api7/api7-ingress-controller
     pullPolicy: IfNotPresent
-    tag: "2.0.16"
+    tag: "2.1.0"
   # -- Set pod resource requests & limits
   resources: {}
 
 adc:
   image:
     repository: ghcr.io/api7/adc
-    tag: "0.23.1"
+    tag: "0.26.0"
     pullPolicy: IfNotPresent
   logLevel: "info"
   resources: {}


### PR DESCRIPTION
## Changes

- Bump ingress-controller image tag: `2.0.16` → `2.1.0`
- Bump chart `appVersion`: `2.0.16` → `2.1.0`, `version`: `0.1.23` → `0.1.24`
- Bump ADC image tag: `0.23.1` → `0.26.0`
- Update CRDs (apisixconsumers, apisixroutes, backendtrafficpolicies) for new 2.1.0 features

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stricter JWT auth validation (requires keys for non-HS algorithms).
  * Consumer plugin support (plugin array with enable/name/config).
  * Expanded HTTP match scopes (Header/Query/Path/Cookie/Variable/Body) and related name validations.
  * Improved health checks with explicit active/passive monitoring and additional thresholds.
  * Control-plane mode made immutable once set.

* **Chores**
  * Chart/app versions bumped; default controller updated to 2.1.0.
  * Ingress controller and ADC image tags updated (controller 2.1.0, ADC 0.26.0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->