### PR TITLE
feat(gateway): support TCP PROXY protocol config

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.70
+version: 0.2.71
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -119,6 +119,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.podLabels | object | `{}` | Labels to add to each pod |
 | apisix.podSecurityContext | object | `{}` | Set the securityContext for API7 Gateway pods |
 | apisix.priorityClassName | string | `""` | Set [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for API7 Gateway pods |
+| apisix.proxyProtocol | object | `{"enableTcpPP":false,"enableTcpPPToUpstream":false}` | PROXY Protocol configuration. |
+| apisix.proxyProtocol.enableTcpPP | bool | `false` | Enable PROXY Protocol for TCP proxy. It works with gateway.stream.tcp. |
+| apisix.proxyProtocol.enableTcpPPToUpstream | bool | `false` | Send PROXY Protocol to the upstream server for TCP proxy. |
 | apisix.replicaCount | int | `1` | kind is DaemonSet, replicaCount not become effective |
 | apisix.resources | object | `{}` | Set pod resource requests & limits |
 | apisix.securityContext | object | `{}` | Set the securityContext for API7 Gateway container |

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -42,6 +42,12 @@ data:
       enable_ipv6: {{ .Values.apisix.enableIPv6 }} # Enable nginx IPv6 resolver
       enable_server_tokens: {{ .Values.apisix.enableServerTokens }} # Whether the APISIX version number should be shown in Server header
 
+      {{- if or .Values.apisix.proxyProtocol.enableTcpPP .Values.apisix.proxyProtocol.enableTcpPPToUpstream }}
+      proxy_protocol:
+        enable_tcp_pp: {{ .Values.apisix.proxyProtocol.enableTcpPP }}
+        enable_tcp_pp_to_upstream: {{ .Values.apisix.proxyProtocol.enableTcpPPToUpstream }}
+      {{- end }}
+
       # proxy_protocol:                   # Proxy Protocol configuration
       #   listen_http_port: 9181          # The port with proxy protocol for http, it differs from node_listen and admin_listen.
       #                                   # This port can only receive http request with proxy protocol, but node_listen & admin_listen

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -42,6 +42,13 @@ apisix:
   # -- Whether the APISIX version number should be shown in Server header
   enableServerTokens: true
 
+  # -- PROXY Protocol configuration.
+  proxyProtocol:
+    # -- Enable PROXY Protocol for TCP proxy. It works with gateway.stream.tcp.
+    enableTcpPP: false
+    # -- Send PROXY Protocol to the upstream server for TCP proxy.
+    enableTcpPPToUpstream: false
+
   # -- Use Pod metadata.uid as the APISIX id.
   setIDFromPodUID: false
 


### PR DESCRIPTION
## Summary
- add apisix.proxyProtocol values for TCP PROXY protocol support
- render apisix.proxy_protocol.enable_tcp_pp and enable_tcp_pp_to_upstream when enabled
- bump gateway chart version to 0.2.71 and update README

## Usage

```yaml
apisix:
  proxyProtocol:
    enableTcpPP: true

gateway:
  stream:
    enabled: true
    tcp:
      - addr: 9100
```

This renders:

```yaml
apisix:
  proxy_protocol:
    enable_tcp_pp: true
    enable_tcp_pp_to_upstream: false
```

## Verification
- helm lint charts/gateway
- helm template api7-gateway charts/gateway
- helm template api7-gateway charts/gateway --set gateway.stream.enabled=true --set 'gateway.stream.tcp[0].addr=9100' --set apisix.proxyProtocol.enableTcpPP=true


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PROXY Protocol configuration options to manage TCP proxy behavior, enabling support for PROXY Protocol and upstream forwarding settings.

* **Chores**
  * Bumped chart version to 0.2.71.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->