### PR TITLE
chore(release): EE-line-encoded chart versioning + per-line branch model

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - "main"
+      - "release/**"
   push:
     branches:
       - "main"
+      - "release/**"
 
 jobs:
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,14 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
+
+# Every line (main + release/*) publishes to the same gh-pages index, so
+# serialize releases to avoid racing on the index commit. Do not cancel an
+# in-progress run, or a release could be dropped.
+concurrency:
+  group: helm-chart-release
+  cancel-in-progress: false
 
 jobs:
   release:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md — API7 EE Helm Charts
+
+本仓库（`api7/api7-helm-chart`）收录 API7 EE 各组件的 Helm chart，发布到公开 Helm repo `https://charts.api7.ai`（由 `gh-pages` 分支 + 自定义域名提供）。
+
+| chart | 目录 | 版本是否等于 EE 版本 |
+|---|---|---|
+| `api7ee3`（Control Plane / Dashboard） | `charts/api7` | 是，appVersion = EE 版本 |
+| `gateway`（Data Plane） | `charts/gateway` | 是，appVersion = EE 版本 |
+| `api7-ingress-controller` | `charts/ingress-controller` | 否，有独立产品版本 |
+| `developer-portal-fe` | `charts/developer-portal-fe` | 否，有独立产品版本 |
+
+## 多版本分支维护模型
+
+API7 EE 同时维护多条受支持的发布线（如 3.9.x、3.10.x），chart 必须能在不互相干扰的前提下分别打补丁。
+
+### 分支布局
+
+- **`main`** = 当前最新发布线（latest），例如现在的 3.10.x。
+- **`release/<major>.<minor>`** = 历史发布线，例如 3.9.x 在 `release/3.9`、3.8.x 在 `release/3.8`。EE 的 major 恒为 3，minor 即"大版本"。
+
+### 切线时机（不变量）
+
+**`main` 永远等于 latest 线。** 当 latest 从 3.10 进到 3.11 时，先 `git branch release/3.10 main` 冻结旧线，**再**在 `main` 上 bump 到 3.11。这样每条被取代的线在被取代的瞬间就有分支，不必事后回去找基点。
+
+新建 `release/<x>.<y>` 时，基点是**该线最后一次发布的 chart 状态**（带有那条线的 values/模板），不是从 `main` 改个号——`main` 可能已经带了更高版本独有的配置。
+
+### 编号规则（承重，决定 `helm upgrade` 语义）
+
+对 **appVersion 等于 EE 版本的 chart（`api7ee3`、`gateway`）**：
+
+- chart 的 `major.minor` **跟随 EE 的 minor**：`main`(3.10) 用 `3.10.*`，`release/3.9` 用 `3.9.*`。
+- chart 的 `patch` 是**这条线 chart 自己的计数器**，与 appVersion（EE app patch）**解耦**。每条线从 `.0` 起。因此会出现 `chart 3.10.0` 部署 `appVersion 3.10.1` 这种情况——以 appVersion 字段为准，chart patch 仅表示"本线第几个 chart"。
+
+为什么这样：同一个 `charts.api7.ai` index 内，`3.9.x < 3.10.x`，于是 `helm upgrade` 默认取最高版永远停在最新线、不会被后发的老线补丁拽回旧版本；想留在老线的用户用 `--version '~3.9'` 锁定。若用不透明线性号（如 `0.18.x`），后发的 3.9 补丁号会窜到 3.10 之上，把 upgrade 语义带乱。
+
+代价：同一条线内 chart 不能再用 major bump 表达破坏性变更——维护线本就只收向后兼容的 bugfix，破坏性变更只跟随 minor（新 EE 线）走。
+
+对 **独立版本的子 chart（`ingress-controller`、`developer-portal-fe`）**：它们的版本号与 EE minor 不是一个轴，**默认跨 EE 线共享、不随 EE 线 fork**。只有当某条 EE 老线必须搭一个不同版本、且要持续收补丁时，才按它们**自身的产品 minor** 单独拉线维护。
+
+## 发布判定
+
+发布 EE `X.Y.Z` 的 chart 时：
+
+- `X.Y` 是 latest 线（== `main` 当前线）→ 改 **`main`**。
+- 否则 → 改 **`release/X.Y`**（不存在则按"切线时机"先建）。
+
+操作铁律：**在任意 `release/*` 分支上，只 bump 这次确实要为该线重发的 chart，其余保持原版本号不动**，让 `CR_SKIP_EXISTING` 自动跳过，避免在子 chart 的线性号空间里撞号。
+
+## 发布机制
+
+`.github/workflows/release.yaml` 在 push 到 `main` 或 `release/**` 时运行 chart-releaser（submodule `helm/chart-releaser-action`）：为每个新版本创建 GitHub Release + `.tgz` 资产，并 merge 更新 `gh-pages` 的 `index.yaml`。要点：
+
+- 触发分支含 `main` 和 `release/**`，老线 push 才能自动出对应 chart。
+- 顶层 `concurrency: { group: helm-chart-release, cancel-in-progress: false }`：所有线共用一个 index，必须串行发布、且不取消进行中的 run，避免丢版本。
+- `CR_SKIP_EXISTING: true`：已发布版本跳过，index 是 merge 累加，多分支天然安全。
+- GitHub Release tag 为 `<chart>-<version>`（如 `gateway-3.9.0`），编号规则保证跨线唯一。
+- `ci.yaml`（lint / ct install / helm-docs）同样覆盖 `release/**`。
+- 改 chart 后用 `helm-docs --chart-search-root=charts` 重新生成各 chart 的 `README.md`，否则 CI 的 helm-docs 校验会失败。
+
+## 用户升级指引
+
+- 跟随最新线：`helm repo update && helm upgrade <release> api7/<chart>`（默认取最高版，始终是最新 EE 线）。
+- 锁定老线：`helm upgrade <release> api7/<chart> --version '~3.9'`（停在 3.9.x，收该线的 chart 补丁，不会跳到 3.10）。
+
+> 跨多个子项目的协同规则（CP/DP/Ingress/docs 等）见工作区根 `AGENTS.md`。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,65 +1,63 @@
 # AGENTS.md — API7 EE Helm Charts
 
-本仓库（`api7/api7-helm-chart`）收录 API7 EE 各组件的 Helm chart，发布到公开 Helm repo `https://charts.api7.ai`（由 `gh-pages` 分支 + 自定义域名提供）。
+This repo (`api7/api7-helm-chart`) holds the Helm charts for API7 EE components and publishes them to the public Helm repo `https://charts.api7.ai` (served from the `gh-pages` branch via a custom domain).
 
-| chart | 目录 | 版本是否等于 EE 版本 |
+| chart | directory | chart version == EE version? |
 |---|---|---|
-| `api7ee3`（Control Plane / Dashboard） | `charts/api7` | 是，appVersion = EE 版本 |
-| `gateway`（Data Plane） | `charts/gateway` | 是，appVersion = EE 版本 |
-| `api7-ingress-controller` | `charts/ingress-controller` | 否，有独立产品版本 |
-| `developer-portal-fe` | `charts/developer-portal-fe` | 否，有独立产品版本 |
+| `api7ee3` (Control Plane / Dashboard) | `charts/api7` | yes — appVersion is the EE version |
+| `gateway` (Data Plane) | `charts/gateway` | yes — appVersion is the EE version |
+| `api7-ingress-controller` | `charts/ingress-controller` | no — independent product version |
+| `developer-portal-fe` | `charts/developer-portal-fe` | no — independent product version |
 
-## 多版本分支维护模型
+## Multi-line maintenance model
 
-API7 EE 同时维护多条受支持的发布线（如 3.9.x、3.10.x），chart 必须能在不互相干扰的前提下分别打补丁。
+API7 EE supports several release lines at once (e.g. 3.9.x and 3.10.x). The charts must let each line receive patches without disturbing the others.
 
-### 分支布局
+### Branch layout
 
-- **`main`** = 当前最新发布线（latest），例如现在的 3.10.x。
-- **`release/<major>.<minor>`** = 历史发布线，例如 3.9.x 在 `release/3.9`、3.8.x 在 `release/3.8`。EE 的 major 恒为 3，minor 即"大版本"。
+- **`main`** = the latest (newest) release line, e.g. 3.10.x today.
+- **`release/<major>.<minor>`** = a historical line, e.g. 3.9.x on `release/3.9`, 3.8.x on `release/3.8`. The EE major is always `3`; the minor is the "feature line".
 
-### 切线时机（不变量）
+### When to cut a line (invariant)
 
-**`main` 永远等于 latest 线。** 当 latest 从 3.10 进到 3.11 时，先 `git branch release/3.10 main` 冻结旧线，**再**在 `main` 上 bump 到 3.11。这样每条被取代的线在被取代的瞬间就有分支，不必事后回去找基点。
+**`main` always equals the latest line.** When the latest moves from 3.10 to 3.11, first `git branch release/3.10 main` to freeze the old line, **then** bump `main` to 3.11. This guarantees every superseded line has a branch the moment it is superseded.
 
-新建 `release/<x>.<y>` 时，基点是**该线最后一次发布的 chart 状态**（带有那条线的 values/模板），不是从 `main` 改个号——`main` 可能已经带了更高版本独有的配置。
+When creating `release/<x>.<y>`, branch from **the last published chart state of that line** (which carries that line's values/templates) — not from `main` renumbered, since `main` may already carry config that only exists in a newer line.
 
-### 编号规则（承重，决定 `helm upgrade` 语义）
+### Version numbering (load-bearing — governs `helm upgrade`)
 
-对 **appVersion 等于 EE 版本的 chart（`api7ee3`、`gateway`）**：
+For charts whose **appVersion is the EE version** (`api7ee3`, `gateway`):
 
-- chart 的 `major.minor` **跟随 EE 的 minor**：`main`(3.10) 用 `3.10.*`，`release/3.9` 用 `3.9.*`。
-- chart 的 `patch` 是**这条线 chart 自己的计数器**，与 appVersion（EE app patch）**解耦**。每条线从 `.0` 起。因此会出现 `chart 3.10.0` 部署 `appVersion 3.10.1` 这种情况——以 appVersion 字段为准，chart patch 仅表示"本线第几个 chart"。
+- the chart's `major.minor` **mirrors the EE minor**: `main` (3.10) uses `3.10.*`, `release/3.9` uses `3.9.*`.
+- the chart's `patch` is **this line's own counter**, decoupled from the app patch (the EE patch). Each line starts at `.0`. So a `chart 3.10.0` may deploy `appVersion 3.10.1` — `appVersion` is the source of truth for the image version; the chart patch only means "the Nth chart on this line".
 
-为什么这样：同一个 `charts.api7.ai` index 内，`3.9.x < 3.10.x`，于是 `helm upgrade` 默认取最高版永远停在最新线、不会被后发的老线补丁拽回旧版本；想留在老线的用户用 `--version '~3.9'` 锁定。若用不透明线性号（如 `0.18.x`），后发的 3.9 补丁号会窜到 3.10 之上，把 upgrade 语义带乱。
+Why: in the shared `charts.api7.ai` index, `3.9.x < 3.10.x`, so a plain `helm upgrade` always stays on the newest line and is never dragged back to an older line by a later patch release, while users who want to stay on an older line pin it with `--version '~3.9'`. An opaque linear scheme (e.g. `0.18.x`) would let a later 3.9 patch sort above 3.10 and break that ordering.
 
-代价：同一条线内 chart 不能再用 major bump 表达破坏性变更——维护线本就只收向后兼容的 bugfix，破坏性变更只跟随 minor（新 EE 线）走。
+Cost: within a single line the chart can no longer use a major bump for breaking changes — but a maintenance line should only take backward-compatible bug fixes; breaking changes ride the next minor (a new EE line).
 
-对 **独立版本的子 chart（`ingress-controller`、`developer-portal-fe`）**：它们的版本号与 EE minor 不是一个轴，**默认跨 EE 线共享、不随 EE 线 fork**。只有当某条 EE 老线必须搭一个不同版本、且要持续收补丁时，才按它们**自身的产品 minor** 单独拉线维护。
+For **independently-versioned sub-charts** (`ingress-controller`, `developer-portal-fe`): their version axis is not the EE minor, so they are **shared across EE lines and not forked per line** by default. Only fork them onto their **own product minor** when an older EE line must ship a different version of them and keep patching it.
 
-## 发布判定
+## Release decision
 
-发布 EE `X.Y.Z` 的 chart 时：
+When releasing the chart for EE `X.Y.Z`:
 
-- `X.Y` 是 latest 线（== `main` 当前线）→ 改 **`main`**。
-- 否则 → 改 **`release/X.Y`**（不存在则按"切线时机"先建）。
+- `X.Y` is the latest line (== `main`'s current line) → edit **`main`**.
+- otherwise → edit **`release/X.Y`** (cut it first per "When to cut a line" if it does not exist).
 
-操作铁律：**在任意 `release/*` 分支上，只 bump 这次确实要为该线重发的 chart，其余保持原版本号不动**，让 `CR_SKIP_EXISTING` 自动跳过，避免在子 chart 的线性号空间里撞号。
+Operational rule: **on any `release/*` branch, only bump the charts you actually intend to re-release for that line; leave the rest at their existing versions** so `CR_SKIP_EXISTING` skips them — this avoids colliding numbers in a sub-chart's linear version space.
 
-## 发布机制
+## Release mechanism
 
-`.github/workflows/release.yaml` 在 push 到 `main` 或 `release/**` 时运行 chart-releaser（submodule `helm/chart-releaser-action`）：为每个新版本创建 GitHub Release + `.tgz` 资产，并 merge 更新 `gh-pages` 的 `index.yaml`。要点：
+`.github/workflows/release.yaml` runs chart-releaser (submodule `helm/chart-releaser-action`) on push to `main` or `release/**`: it creates a GitHub Release + `.tgz` asset per new version and merges the update into the `gh-pages` `index.yaml`. Notes:
 
-- 触发分支含 `main` 和 `release/**`，老线 push 才能自动出对应 chart。
-- 顶层 `concurrency: { group: helm-chart-release, cancel-in-progress: false }`：所有线共用一个 index，必须串行发布、且不取消进行中的 run，避免丢版本。
-- `CR_SKIP_EXISTING: true`：已发布版本跳过，index 是 merge 累加，多分支天然安全。
-- GitHub Release tag 为 `<chart>-<version>`（如 `gateway-3.9.0`），编号规则保证跨线唯一。
-- `ci.yaml`（lint / ct install / helm-docs）同样覆盖 `release/**`。
-- 改 chart 后用 `helm-docs --chart-search-root=charts` 重新生成各 chart 的 `README.md`，否则 CI 的 helm-docs 校验会失败。
+- triggers include `main` and `release/**`, so a push to an older line publishes its own charts.
+- top-level `concurrency: { group: helm-chart-release, cancel-in-progress: false }`: all lines share one index, so releases must be serialized and an in-progress run must never be cancelled, or a release could be dropped.
+- `CR_SKIP_EXISTING: true`: already-released versions are skipped and the index is merged (not overwritten), so multiple branches are safe.
+- the GitHub Release tag is `<chart>-<version>` (e.g. `gateway-3.9.0`); the numbering rule keeps it unique across lines.
+- `ci.yaml` (lint / ct install / helm-docs) also covers `release/**`.
+- after editing a chart, regenerate each chart's `README.md` with `helm-docs --chart-search-root=charts`, or the helm-docs CI check fails.
 
-## 用户升级指引
+## User upgrade guidance
 
-- 跟随最新线：`helm repo update && helm upgrade <release> api7/<chart>`（默认取最高版，始终是最新 EE 线）。
-- 锁定老线：`helm upgrade <release> api7/<chart> --version '~3.9'`（停在 3.9.x，收该线的 chart 补丁，不会跳到 3.10）。
-
-> 跨多个子项目的协同规则（CP/DP/Ingress/docs 等）见工作区根 `AGENTS.md`。
+- Follow the latest line: `helm repo update && helm upgrade <release> api7/<chart>` (picks the highest version, always the newest EE line).
+- Pin an older line: `helm upgrade <release> api7/<chart> --version '~3.9'` (stays on 3.9.x and takes that line's chart patches without jumping to 3.10).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -15,7 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.18.4
+# major.minor mirrors the API7 EE release line (3.10.x), patch is this chart's
+# own counter on that line and is decoupled from the app patch (see appVersion).
+version: 3.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -1,6 +1,6 @@
 # api7ee3
 
-![Version: 0.18.4](https://img.shields.io/badge/Version-0.18.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.10.1](https://img.shields.io/badge/AppVersion-3.10.1-informational?style=flat-square)
+![Version: 3.10.0](https://img.shields.io/badge/Version-3.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.10.1](https://img.shields.io/badge/AppVersion-3.10.1-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -14,7 +14,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.71
+# major.minor mirrors the API7 EE release line (3.10.x), patch is this chart's
+# own counter on that line and is decoupled from the app patch (see appVersion).
+version: 3.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Establishes a multi-line maintenance model so historical EE release lines can receive chart patches without disturbing the latest line.

## Problem

Chart versions for `api7ee3` / `gateway` were a single linear sequence (`0.18.x`) that monotonically tracked the latest app version. Once `main` advanced to 3.10.x, there was no version space to ship a chart for an older line (e.g. 3.9.14): the next linear number (`0.18.5`) would sort **above** `0.18.4` (=3.10.1) in the shared `charts.api7.ai` index, so `helm upgrade` / `helm search` would surface a 3.9 chart as "newest" and silently downgrade 3.10 users.

## Approach

For charts whose `appVersion` **is** the EE version (`api7ee3`, `gateway`):

- chart `major.minor` mirrors the EE release line — `main` (3.10) uses `3.10.*`, `release/3.9` uses `3.9.*`.
- chart `patch` is an independent per-line counter, decoupled from the app patch; each line starts at `.0`. `appVersion` remains the source of truth for the deployed image version.

This keeps `3.9.x < 3.10.x` in the index: plain `helm upgrade` stays on the newest line, while `--version ~3.9` pins an older line. Combined with per-line `release/<major>.<minor>` branches, an older line can be patched in isolation.

Independently-versioned sub-charts (`ingress-controller`, `developer-portal-fe`) are intentionally left on their own version sequences and shared across lines.

## Changes

- `api7ee3` / `gateway`: `0.18.4` / `0.2.71` → `3.10.0` (appVersion unchanged at `3.10.1`); READMEs regenerated via helm-docs.
- `release.yaml`: trigger on `release/**` and add `concurrency: helm-chart-release` (serialize publishes to the shared gh-pages index, never cancel in-progress).
- `ci.yaml`: run lint / install / helm-docs on `release/**` too.
- New `AGENTS.md` (+ `CLAUDE.md` symlink) documenting the branch model, numbering rule, release decision, sub-chart policy and user upgrade guidance.

## Behavior / compatibility

- On merge, chart-releaser publishes `api7ee3-3.10.0` / `gateway-3.10.0`. `3.10.0 > 0.18.4`, so existing 3.10 users upgrade forward normally.
- The jump from `0.x` to `3.x` chart versions is intentional and one-way; legacy `0.x` versions remain installable by exact version.
- No template/values behavior change — version metadata and CI triggers only.

The `release/3.9` branch and the 3.9.14 chart will follow in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive release and maintenance documentation detailing branching strategy, versioning scheme, and publication workflow.

* **CI/CD Improvements**
  * Enhanced CI workflows to trigger on release branches and implemented serialized concurrency control for release deployments.

* **Chart Updates**
  * Updated Helm chart versions (api7 and gateway) to align with API7 EE major.minor versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->