### PR TITLE
chore: upgrade api7 and gateway to v3.9.14 (3.9 maintenance line)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - "main"
+      - "release/**"
   push:
     branches:
       - "main"
+      - "release/**"
 
 jobs:
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,14 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
+
+# Every line (main + release/*) publishes to the same gh-pages index, so
+# serialize releases to avoid racing on the index commit. Do not cancel an
+# in-progress run, or a release could be dropped.
+concurrency:
+  group: helm-chart-release
+  cancel-in-progress: false
 
 jobs:
   release:

--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -15,13 +15,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.18.2
+# major.minor mirrors the API7 EE release line (3.9.x), patch is this chart's
+# own counter on that line and is decoupled from the app patch (see appVersion).
+version: 3.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.9.13"
+appVersion: "3.9.14"
 
 maintainers:
   - name: API7

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -1,6 +1,6 @@
 # api7ee3
 
-![Version: 0.18.2](https://img.shields.io/badge/Version-0.18.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.13](https://img.shields.io/badge/AppVersion-3.9.13-informational?style=flat-square)
+![Version: 3.9.0](https://img.shields.io/badge/Version-3.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.14](https://img.shields.io/badge/AppVersion-3.9.14-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -29,7 +29,7 @@ A Helm chart for Kubernetes
 | dashboard.extraVolumes | list | `[]` |  |
 | dashboard.image.pullPolicy | string | `"Always"` |  |
 | dashboard.image.repository | string | `"api7/api7-ee-3-integrated"` |  |
-| dashboard.image.tag | string | `"v3.9.13"` |  |
+| dashboard.image.tag | string | `"v3.9.14"` |  |
 | dashboard.keyCertSecret | string | `""` |  |
 | dashboard.livenessProbe.failureThreshold | int | `30` |  |
 | dashboard.livenessProbe.initialDelaySeconds | int | `180` |  |
@@ -120,7 +120,7 @@ A Helm chart for Kubernetes
 | developer_portal.extraVolumes | list | `[]` |  |
 | developer_portal.image.pullPolicy | string | `"Always"` |  |
 | developer_portal.image.repository | string | `"api7/api7-ee-developer-portal"` |  |
-| developer_portal.image.tag | string | `"v3.9.13"` |  |
+| developer_portal.image.tag | string | `"v3.9.14"` |  |
 | developer_portal.keyCertSecret | string | `""` |  |
 | developer_portal.livenessProbe.failureThreshold | int | `10` |  |
 | developer_portal.livenessProbe.initialDelaySeconds | int | `60` |  |
@@ -166,7 +166,7 @@ A Helm chart for Kubernetes
 | dp_manager.extraVolumes | list | `[]` |  |
 | dp_manager.image.pullPolicy | string | `"Always"` |  |
 | dp_manager.image.repository | string | `"api7/api7-ee-dp-manager"` |  |
-| dp_manager.image.tag | string | `"v3.9.13"` |  |
+| dp_manager.image.tag | string | `"v3.9.14"` |  |
 | dp_manager.livenessProbe.failureThreshold | int | `10` |  |
 | dp_manager.livenessProbe.initialDelaySeconds | int | `60` |  |
 | dp_manager.livenessProbe.periodSeconds | int | `3` |  |
@@ -232,7 +232,7 @@ A Helm chart for Kubernetes
 | file_server.enabled | bool | `false` |  |
 | file_server.image.pullPolicy | string | `"Always"` |  |
 | file_server.image.repository | string | `"api7/api7-ee-file-server"` |  |
-| file_server.image.tag | string | `"v3.9.13"` |  |
+| file_server.image.tag | string | `"v3.9.14"` |  |
 | file_server.livenessProbe.failureThreshold | int | `10` |  |
 | file_server.livenessProbe.initialDelaySeconds | int | `60` |  |
 | file_server.livenessProbe.periodSeconds | int | `3` |  |

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -18,7 +18,7 @@ dashboard:
     repository: api7/api7-ee-3-integrated
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.13"
+    tag: "v3.9.14"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -55,7 +55,7 @@ dp_manager:
     repository: api7/api7-ee-dp-manager
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.13"
+    tag: "v3.9.14"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -92,7 +92,7 @@ file_server:
   image:
     repository: api7/api7-ee-file-server
     pullPolicy: Always
-    tag: "v3.9.13"
+    tag: "v3.9.14"
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 3
@@ -110,7 +110,7 @@ developer_portal:
     repository: api7/api7-ee-developer-portal
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.13"
+    tag: "v3.9.14"
 
   extraEnvVars: []
   extraVolumes: []

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -14,12 +14,14 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.68
+# major.minor mirrors the API7 EE release line (3.9.x), patch is this chart's
+# own counter on that line and is decoupled from the app patch (see appVersion).
+version: 3.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "3.9.13"
+appVersion: "3.9.14"
 
 maintainers:
   - name: API7

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -103,7 +103,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.httpRouter | string | `"radixtree_host_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
 | apisix.image.pullPolicy | string | `"Always"` | API7 Gateway image pull policy |
 | apisix.image.repository | string | `"api7/api7-ee-3-gateway"` | API7 Gateway image repository |
-| apisix.image.tag | string | `"3.9.13"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
+| apisix.image.tag | string | `"3.9.14"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
 | apisix.kind | string | `"Deployment"` | Use a `DaemonSet` or `Deployment` |
 | apisix.lru | object | `{"secret":{"count":512,"neg_count":512,"neg_ttl":60,"ttl":300}}` | fine tune the parameters of LRU cache for some features like secret |
 | apisix.lru.secret.neg_ttl | int | `60` | in seconds |

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -120,7 +120,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.podSecurityContext | object | `{}` | Set the securityContext for API7 Gateway pods |
 | apisix.priorityClassName | string | `""` | Set [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for API7 Gateway pods |
 | apisix.replicaCount | int | `1` | kind is DaemonSet, replicaCount not become effective |
-| apisix.requestBodyJsonLib | string | `"simdjson"` | JSON library used to decode request bodies parsed by core.request. Also controls AI upstream request body encoding. Allowed values: `cjson`, `simdjson`, `qjson`. |
 | apisix.resources | object | `{}` | Set pod resource requests & limits |
 | apisix.securityContext | object | `{}` | Set the securityContext for API7 Gateway container |
 | apisix.setIDFromPodUID | bool | `false` | Use Pod metadata.uid as the APISIX id. |

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -36,8 +36,6 @@ data:
       {{- if .Values.apisix.extraLuaCPath }}
       extra_lua_cpath: "{{ .Values.apisix.extraLuaCPath }};"
       {{- end }}
-      request_body_json_lib: {{ .Values.apisix.requestBodyJsonLib }}
-
       enable_dev_mode: false                       # Sets nginx worker_processes to 1 if set to true
       enable_reuseport: true                       # Enable nginx SO_REUSEPORT switch if set to true.
       enable_ipv6: {{ .Values.apisix.enableIPv6 }} # Enable nginx IPv6 resolver

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -114,8 +114,6 @@ apisix:
 
   extraLuaPath: ""
   extraLuaCPath: ""
-  # -- JSON library used to decode request bodies parsed by core.request. Also controls AI upstream request body encoding. Allowed values: `cjson`, `simdjson`, `qjson`.
-  requestBodyJsonLib: simdjson
 
   # -- Delete the '/' at the end of the URI
   deleteURITailSlash: false

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -143,7 +143,7 @@ apisix:
     pullPolicy: Always
     # -- API7 Gateway image tag
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.9.13
+    tag: 3.9.14
 
   # -- Use a `DaemonSet` or `Deployment`
   kind: Deployment


### PR DESCRIPTION
Establishes the first chart on the `release/3.9` maintenance line under the EE-line-encoded versioning scheme, and ships the 3.9.14 chart.

Depends on the model introduced in #294 (numbering rule + branch model). `release/3.9` was cut from the v3.9.13 release commit (`api7ee3-0.18.2` / `gateway-0.2.68`), so it carries the 3.9-era templates/values rather than a renumbered copy of `main` (which already has 3.10-only config).

## Changes

- `api7ee3` / `gateway`: chart `version` → `3.9.0` (3.9 line; patch is this line own counter, decoupled from the app patch), `appVersion` → `3.9.14`, image tags → `v3.9.14` / `3.9.14`.
- Drop `request_body_json_lib` from the gateway chart: the configurable request JSON library was reverted in gateway 3.9.14 (removed from config-default.yaml and code), so the chart no longer renders it. This is a 3.9.13 → 3.9.14 delta that previously had nowhere to land because the 3.9 line had no releasable chart; `main` already dropped it in the 3.10.0 chart.
- Backport the `release/**` trigger + `concurrency: helm-chart-release` to this branch so pushes to `release/3.9` publish their own charts to the shared `charts.api7.ai` index.
- Regenerate `charts/{api7,gateway}/README.md` via helm-docs.

## Other 3.9.13 → 3.9.14 deltas (no chart change needed)

- `control-plane/helm` is unchanged between `v3.9.13` and `v3.9.14`.
- The remaining `gateway/conf/config-default.yaml` deltas (`nacos-stream` shared dict, prometheus `llm_*` buckets) ship inside the gateway image and are not templated by the chart.

## Behavior / compatibility

- On merge, chart-releaser publishes `api7ee3-3.9.0` / `gateway-3.9.0`. In the index `3.9.x < 3.10.x`, so plain `helm upgrade` stays on the latest (3.10) line; users on the 3.9 line pin it with `--version "~3.9"`.
- CI triggers extended to `release/**`.