### PR TITLE
chore(gateway): drop dead telemetry config from chart (3.9)

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.9.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.9.0
+version: 3.9.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -55,11 +55,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | api7ee.status_endpoint.enabled | bool | `false` | When enabled, APISIX will provide `/status` and `/status/ready` endpoints, /status endpoint will return 200 status code if APISIX has successfully started and running correctly, /status/ready endpoint will return 503 status code if none of the configured etcd (dp_manager) are available. |
 | api7ee.status_endpoint.ip | string | `"0.0.0.0"` | The IP address and port on which the status endpoint will listen. |
 | api7ee.status_endpoint.port | int | `7085` | The port on which the status endpoint will listen. |
-| api7ee.telemetry.compression_level | int | `-1` | gzip compression level. -1 uses library default (usually 6).Range 0-9; 1 fastest, 9 highest compression. Gzip is enabled by default. |
-| api7ee.telemetry.enable | bool | `true` | enable telemetry data report to the control plane |
-| api7ee.telemetry.interval | int | `15` | interval in seconds to send telemetry data to the control plane |
-| api7ee.telemetry.max_metrics_size | int | `33554432` | max size in bytes(default 32M) of the metrics data sent to the control plane, if the size exceeds, the data will be truncated |
-| api7ee.telemetry.metrics_batch_size | int | `4194304` | max batch size before compression (bytes, 4 MiB). |
 | apisix.affinity | object | `{}` | Set affinity for API7 Gateway deploy |
 | apisix.customLuaSharedDicts | list | `[]` | Add custom [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings, click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict |
 | apisix.customizedConfig | object | `{}` | If apisix.enableCustomizedConfig is true, full customized config.yaml. Please note that other settings about APISIX config will be ignored |

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -7,17 +7,6 @@ global:
   imagePullSecrets: []
 
 api7ee:
-  telemetry:
-    # -- enable telemetry data report to the control plane
-    enable: true
-    # -- interval in seconds to send telemetry data to the control plane
-    interval: 15
-    # -- max size in bytes(default 32M) of the metrics data sent to the control plane, if the size exceeds, the data will be truncated
-    max_metrics_size: 33554432
-    # -- max batch size before compression (bytes, 4 MiB).
-    metrics_batch_size: 4194304
-    # -- gzip compression level. -1 uses library default (usually 6).Range 0-9; 1 fastest, 9 highest compression. Gzip is enabled by default.
-    compression_level: -1
   # -- healthcheck data report interval in seconds
   healthcheck_report_interval: 120
 


### PR DESCRIPTION
## What

Remove the `api7ee.telemetry` block from the gateway chart `values.yaml` and bump the gateway chart to `3.9.1` on the 3.9 maintenance line.

## Why

Since control-plane #2576, telemetry config (enable / interval / max_metrics_size / metrics_batch_size / compression_level) is managed by the Control Plane and pushed to the gateway through the heartbeat `config_payload`. The gateway agent merges the control-plane payload over the local config file with **CP taking precedence**, so the chart's local `api7ee.telemetry` values are dead config — they never take effect and only mislead operators into thinking they can tune telemetry from the chart.

## Behavior change

None at runtime — these values were already overridden by the control plane. This only removes the inert keys from the chart.

`api7ee.healthcheck_report_interval` is a separate setting, not part of #2576, and is kept.

## Notes

README regenerated with `helm-docs`. Targets the 3.9 line (`release/3.9`); the 3.10 line is handled separately against `main`.