### PR TITLE
chore: upgrade api7 and gateway to v3.9.15

### DIFF
--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.9.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.9.0
+version: 3.9.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.9.14"
+appVersion: "3.9.15"
 
 maintainers:
   - name: API7

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -1,6 +1,6 @@
 # api7ee3
 
-![Version: 3.9.0](https://img.shields.io/badge/Version-3.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.14](https://img.shields.io/badge/AppVersion-3.9.14-informational?style=flat-square)
+![Version: 3.9.1](https://img.shields.io/badge/Version-3.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.15](https://img.shields.io/badge/AppVersion-3.9.15-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -29,7 +29,7 @@ A Helm chart for Kubernetes
 | dashboard.extraVolumes | list | `[]` |  |
 | dashboard.image.pullPolicy | string | `"Always"` |  |
 | dashboard.image.repository | string | `"api7/api7-ee-3-integrated"` |  |
-| dashboard.image.tag | string | `"v3.9.14"` |  |
+| dashboard.image.tag | string | `"v3.9.15"` |  |
 | dashboard.keyCertSecret | string | `""` |  |
 | dashboard.livenessProbe.failureThreshold | int | `30` |  |
 | dashboard.livenessProbe.initialDelaySeconds | int | `180` |  |
@@ -120,7 +120,7 @@ A Helm chart for Kubernetes
 | developer_portal.extraVolumes | list | `[]` |  |
 | developer_portal.image.pullPolicy | string | `"Always"` |  |
 | developer_portal.image.repository | string | `"api7/api7-ee-developer-portal"` |  |
-| developer_portal.image.tag | string | `"v3.9.14"` |  |
+| developer_portal.image.tag | string | `"v3.9.15"` |  |
 | developer_portal.keyCertSecret | string | `""` |  |
 | developer_portal.livenessProbe.failureThreshold | int | `10` |  |
 | developer_portal.livenessProbe.initialDelaySeconds | int | `60` |  |
@@ -166,7 +166,7 @@ A Helm chart for Kubernetes
 | dp_manager.extraVolumes | list | `[]` |  |
 | dp_manager.image.pullPolicy | string | `"Always"` |  |
 | dp_manager.image.repository | string | `"api7/api7-ee-dp-manager"` |  |
-| dp_manager.image.tag | string | `"v3.9.14"` |  |
+| dp_manager.image.tag | string | `"v3.9.15"` |  |
 | dp_manager.livenessProbe.failureThreshold | int | `10` |  |
 | dp_manager.livenessProbe.initialDelaySeconds | int | `60` |  |
 | dp_manager.livenessProbe.periodSeconds | int | `3` |  |
@@ -232,7 +232,7 @@ A Helm chart for Kubernetes
 | file_server.enabled | bool | `false` |  |
 | file_server.image.pullPolicy | string | `"Always"` |  |
 | file_server.image.repository | string | `"api7/api7-ee-file-server"` |  |
-| file_server.image.tag | string | `"v3.9.14"` |  |
+| file_server.image.tag | string | `"v3.9.15"` |  |
 | file_server.livenessProbe.failureThreshold | int | `10` |  |
 | file_server.livenessProbe.initialDelaySeconds | int | `60` |  |
 | file_server.livenessProbe.periodSeconds | int | `3` |  |

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -18,7 +18,7 @@ dashboard:
     repository: api7/api7-ee-3-integrated
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.14"
+    tag: "v3.9.15"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -55,7 +55,7 @@ dp_manager:
     repository: api7/api7-ee-dp-manager
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.14"
+    tag: "v3.9.15"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -92,7 +92,7 @@ file_server:
   image:
     repository: api7/api7-ee-file-server
     pullPolicy: Always
-    tag: "v3.9.14"
+    tag: "v3.9.15"
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 3
@@ -110,7 +110,7 @@ developer_portal:
     repository: api7/api7-ee-developer-portal
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.14"
+    tag: "v3.9.15"
 
   extraEnvVars: []
   extraVolumes: []

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -16,12 +16,12 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.9.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.9.1
+version: 3.9.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "3.9.14"
+appVersion: "3.9.15"
 
 maintainers:
   - name: API7

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -98,7 +98,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.httpRouter | string | `"radixtree_host_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
 | apisix.image.pullPolicy | string | `"Always"` | API7 Gateway image pull policy |
 | apisix.image.repository | string | `"api7/api7-ee-3-gateway"` | API7 Gateway image repository |
-| apisix.image.tag | string | `"3.9.14"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
+| apisix.image.tag | string | `"3.9.15"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
 | apisix.kind | string | `"Deployment"` | Use a `DaemonSet` or `Deployment` |
 | apisix.lru | object | `{"secret":{"count":512,"neg_count":512,"neg_ttl":60,"ttl":300}}` | fine tune the parameters of LRU cache for some features like secret |
 | apisix.lru.secret.neg_ttl | int | `60` | in seconds |

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -47,8 +47,10 @@ data:
       #                                   # can only receive http request. If you enable proxy protocol, you must use this port to
       #                                   # receive http request with proxy protocol
       #   listen_https_port: 9182         # The port with proxy protocol for https
-      #   enable_tcp_pp: true             # Enable the proxy protocol for tcp proxy, it works for stream_proxy.tcp option
-      #   enable_tcp_pp_to_upstream: true # Enables the proxy protocol to the upstream server
+      #   enable_tcp_pp: true             # Accept the proxy protocol on every stream_proxy.tcp port. Acts as the default;
+      #                                   # override per port with the `proxy_protocol` field on a gateway.stream.tcp entry.
+      #   enable_tcp_pp_to_upstream: true # Send the proxy protocol to the upstream on every stream_proxy.tcp port. Acts as
+      #                                   # the default; override per port with `proxy_protocol_to_upstream` on an entry.
 
       proxy_cache:                         # Proxy Caching configuration
         cache_ttl: 10s                     # The default caching time if the upstream does not specify the cache time
@@ -87,6 +89,12 @@ data:
           - addr: {{ .addr | quote }}
           {{- if hasKey . "tls" }}
             tls: {{ .tls }}
+          {{- end }}
+          {{- if hasKey . "proxy_protocol" }}
+            proxy_protocol: {{ .proxy_protocol }}
+          {{- end }}
+          {{- if hasKey . "proxy_protocol_to_upstream" }}
+            proxy_protocol_to_upstream: {{ .proxy_protocol_to_upstream }}
           {{- end }}
           {{- else if kindIs "string" . }}
           - {{ . | quote }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -130,7 +130,7 @@ apisix:
     pullPolicy: Always
     # -- API7 Gateway image tag
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.9.14
+    tag: 3.9.15
 
   # -- Use a `DaemonSet` or `Deployment`
   kind: Deployment
@@ -359,6 +359,10 @@ gateway:
       # - addr: 192.168.31.10:5432
       # - addr: 3302
       #   nodePort: 31302
+      # - addr: 5432
+      #   proxy_protocol: true               # accept the proxy protocol on this port only
+      #   proxy_protocol_to_upstream: true   # send the proxy protocol to the upstream on this port only;
+      #                                      # both override the global proxy_protocol.enable_tcp_pp* defaults
       # - "2000-2100"                   # port range (nginx native support)
       # - addr: "3000-3100"             # port range in table form
       # - addr: "127.0.0.1:4000-4100"   # address with port range


### PR DESCRIPTION
Upgrade the api7 and gateway charts to API7 Enterprise v3.9.15 (3.9 release line).

### Version bumps
- **api7**: chart `3.9.0` → `3.9.1`, appVersion → `3.9.15`, image tags → `v3.9.15` (integrated, dp_manager, file_server, developer_portal)
- **gateway**: chart `3.9.1` → `3.9.2`, appVersion → `3.9.15`, image tag → `3.9.15`

### Structural change
- **gateway**: expose per-port PROXY protocol for stream TCP. Each `gateway.stream.tcp` map entry now accepts `proxy_protocol` and `proxy_protocol_to_upstream`, rendered into `stream_proxy.tcp`; these override the global `proxy_protocol.enable_tcp_pp*` defaults. The commented global section and the `gateway.stream.tcp` example were updated accordingly. READMEs regenerated via `make helm-docs`.

No Control Plane chart structural changes in this release.
