### PR TITLE
chore: bump ADC image tag to 0.27.1

### DIFF
--- a/charts/ingress-controller/Chart.yaml
+++ b/charts/ingress-controller/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - api7
   - crd
 type: application
-version: 0.1.24
+version: 0.1.25
 appVersion: 2.1.0
 maintainers:
   - name: API7

--- a/charts/ingress-controller/README.md
+++ b/charts/ingress-controller/README.md
@@ -20,7 +20,7 @@ Ingress Controller for API7
 |-----|------|---------|-------------|
 | adc.image.pullPolicy | string | `"IfNotPresent"` |  |
 | adc.image.repository | string | `"ghcr.io/api7/adc"` |  |
-| adc.image.tag | string | `"0.26.0"` |  |
+| adc.image.tag | string | `"0.27.1"` |  |
 | adc.logLevel | string | `"info"` |  |
 | adc.resources | object | `{}` |  |
 | adc.securityContext | object | `{}` |  |

--- a/charts/ingress-controller/values.yaml
+++ b/charts/ingress-controller/values.yaml
@@ -41,7 +41,7 @@ deployment:
 adc:
   image:
     repository: ghcr.io/api7/adc
-    tag: "0.26.0"
+    tag: "0.27.1"
     pullPolicy: IfNotPresent
   logLevel: "info"
   resources: {}


### PR DESCRIPTION
## What

Bump the ADC image tag used by the `ingress-controller` chart from `0.26.0` to `0.27.1`.

## Changes

- `charts/ingress-controller/values.yaml`: `adc.image.tag` `0.26.0` -> `0.27.1`
- `charts/ingress-controller/README.md`: regenerate the `adc.image.tag` default
- `charts/ingress-controller/Chart.yaml`: bump chart `version` `0.1.24` -> `0.1.25`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ingress controller Helm chart to version 0.1.25
  * Upgraded ADC component to version 0.27.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->