### PR TITLE
release(aisix-cp): 0.2.0

### DIFF
--- a/charts/aisix-cp/Chart.yaml
+++ b/charts/aisix-cp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix-cp
 description: Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 
 maintainers:
   - name: API7

--- a/charts/aisix-cp/README.md
+++ b/charts/aisix-cp/README.md
@@ -1,6 +1,6 @@
 # aisix-cp
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 
@@ -65,6 +65,7 @@ Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 | dpm.securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | dpm.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | dpm.securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| dpm.service.healthListen | string | `":7946"` |  |
 | dpm.service.nodePort | string | `""` |  |
 | dpm.service.port | int | `7944` |  |
 | dpm.service.type | string | `"ClusterIP"` |  |

--- a/charts/aisix-cp/templates/dpm-deployment.yaml
+++ b/charts/aisix-cp/templates/dpm-deployment.yaml
@@ -36,6 +36,11 @@ spec:
             - name: tls
               containerPort: 7944
               protocol: TCP
+            {{- if .Values.dpm.service.healthListen }}
+            - name: health
+              containerPort: {{ trimPrefix ":" .Values.dpm.service.healthListen | int }}
+              protocol: TCP
+            {{- end }}
           env:
             - name: PGPASSWORD
               valueFrom:
@@ -44,6 +49,8 @@ spec:
                   key: {{ include "aisix-cp.pgPasswordSecretKey" . }}
             - name: AISIX_DPMGR_LISTEN
               value: ":7944"
+            - name: AISIX_DPMGR_HEALTH_LISTEN
+              value: {{ .Values.dpm.service.healthListen | quote }}
             - name: AISIX_DPMGR_DATABASE_URL
               value: {{ include "aisix-cp.databaseURL" . }}
             - name: AISIX_DPMGR_MASTER_KEY
@@ -56,6 +63,28 @@ spec:
             {{- with .Values.dpm.extraEnvVars }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          # Probe the plain-HTTP /healthz (poller liveness), not the
+          # mTLS port: a kubelet cannot present a client cert, and a
+          # TCP check on 7944 stays green even if the outbox poller is
+          # dead/wedged. A stale poller fails readiness (removed from the
+          # Service) and liveness (pod restarted). When the health
+          # listener is disabled (healthListen=""), the dp-manager serves
+          # no /healthz, so fall back to a TCP check on the mTLS port.
+          {{- if .Values.dpm.service.healthListen }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          {{- else }}
           readinessProbe:
             tcpSocket:
               port: tls
@@ -66,6 +95,7 @@ spec:
               port: tls
             initialDelaySeconds: 10
             periodSeconds: 10
+          {{- end }}
           {{- with .Values.dpm.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/aisix-cp/values.yaml
+++ b/charts/aisix-cp/values.yaml
@@ -52,6 +52,11 @@ dpm:
   service:
     type: ClusterIP
     port: 7944
+    # Plain-HTTP listen address for /healthz (outbox-poller liveness),
+    # probed by the kubelet (the mTLS port 7944 cannot be probed). Set to
+    # "" to disable the health server + httpGet probes (the probes then
+    # fall back to a TCP check on the mTLS port).
+    healthListen: ":7946"
     nodePort: ""
   resources:
     requests:


### PR DESCRIPTION
0.2.0 release sync of the public `aisix-cp` chart.

Bumps `version` and `appVersion` 0.1.0 → 0.2.0. `appVersion` pins the image tags, which now resolve to the published `docker.io/api7/{aisix,aisix-cp-api,aisix-cp-dpm,aisix-cp-ui}:0.2.0`.

Functional delta synced from the source-of-truth CP chart (`control-plane/helm/aisix-cp`):

- **dp-manager `/healthz` liveness.** Adds a plain-HTTP health listener (`AISIX_DPMGR_HEALTH_LISTEN`, default `:7946`) exposed as the `health` container port, with `httpGet /healthz` readiness + liveness probes. This probes outbox-poller liveness rather than the mTLS port 7944 (a kubelet cannot present a client cert, and a TCP check on 7944 stays green even if the poller is wedged): a stale poller now fails readiness (removed from the Service) and liveness (pod restarted). When `dpm.service.healthListen=""`, the dp-manager serves no `/healthz` and the probes fall back to a TCP check on the mTLS port.

Public adaptations preserved (unchanged from 0.1.0): `docker.io` registries, empty image `tag` → `.Chart.AppVersion`, `api.dpImage` default → `docker.io/api7/aisix:<appVersion>`, and the chart README. README regenerated via `helm-docs`.

Merging publishes `aisix-cp-0.2.0` to https://charts.api7.ai.