### PR TITLE
chore: upgrade api7 and gateway to v3.10.2

### DIFF
--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.10.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.10.0
+version: 3.10.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.10.1"
+appVersion: "3.10.2"
 
 maintainers:
   - name: API7

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -1,6 +1,6 @@
 # api7ee3
 
-![Version: 3.10.0](https://img.shields.io/badge/Version-3.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.10.1](https://img.shields.io/badge/AppVersion-3.10.1-informational?style=flat-square)
+![Version: 3.10.1](https://img.shields.io/badge/Version-3.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.10.2](https://img.shields.io/badge/AppVersion-3.10.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -29,7 +29,7 @@ A Helm chart for Kubernetes
 | dashboard.extraVolumes | list | `[]` |  |
 | dashboard.image.pullPolicy | string | `"Always"` |  |
 | dashboard.image.repository | string | `"api7/api7-ee-3-integrated"` |  |
-| dashboard.image.tag | string | `"v3.10.1"` |  |
+| dashboard.image.tag | string | `"v3.10.2"` |  |
 | dashboard.keyCertSecret | string | `""` |  |
 | dashboard.livenessProbe.failureThreshold | int | `30` |  |
 | dashboard.livenessProbe.initialDelaySeconds | int | `180` |  |
@@ -120,7 +120,7 @@ A Helm chart for Kubernetes
 | developer_portal.extraVolumes | list | `[]` |  |
 | developer_portal.image.pullPolicy | string | `"Always"` |  |
 | developer_portal.image.repository | string | `"api7/api7-ee-developer-portal"` |  |
-| developer_portal.image.tag | string | `"v3.10.1"` |  |
+| developer_portal.image.tag | string | `"v3.10.2"` |  |
 | developer_portal.keyCertSecret | string | `""` |  |
 | developer_portal.livenessProbe.failureThreshold | int | `10` |  |
 | developer_portal.livenessProbe.initialDelaySeconds | int | `60` |  |
@@ -166,7 +166,7 @@ A Helm chart for Kubernetes
 | dp_manager.extraVolumes | list | `[]` |  |
 | dp_manager.image.pullPolicy | string | `"Always"` |  |
 | dp_manager.image.repository | string | `"api7/api7-ee-dp-manager"` |  |
-| dp_manager.image.tag | string | `"v3.10.1"` |  |
+| dp_manager.image.tag | string | `"v3.10.2"` |  |
 | dp_manager.livenessProbe.failureThreshold | int | `10` |  |
 | dp_manager.livenessProbe.initialDelaySeconds | int | `60` |  |
 | dp_manager.livenessProbe.periodSeconds | int | `3` |  |
@@ -232,7 +232,7 @@ A Helm chart for Kubernetes
 | file_server.enabled | bool | `false` |  |
 | file_server.image.pullPolicy | string | `"Always"` |  |
 | file_server.image.repository | string | `"api7/api7-ee-file-server"` |  |
-| file_server.image.tag | string | `"v3.10.1"` |  |
+| file_server.image.tag | string | `"v3.10.2"` |  |
 | file_server.livenessProbe.failureThreshold | int | `10` |  |
 | file_server.livenessProbe.initialDelaySeconds | int | `60` |  |
 | file_server.livenessProbe.periodSeconds | int | `3` |  |

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -18,7 +18,7 @@ dashboard:
     repository: api7/api7-ee-3-integrated
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.10.1"
+    tag: "v3.10.2"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -55,7 +55,7 @@ dp_manager:
     repository: api7/api7-ee-dp-manager
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.10.1"
+    tag: "v3.10.2"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -92,7 +92,7 @@ file_server:
   image:
     repository: api7/api7-ee-file-server
     pullPolicy: Always
-    tag: "v3.10.1"
+    tag: "v3.10.2"
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 3
@@ -110,7 +110,7 @@ developer_portal:
     repository: api7/api7-ee-developer-portal
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.10.1"
+    tag: "v3.10.2"
 
   extraEnvVars: []
   extraVolumes: []

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -16,12 +16,12 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.10.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.10.1
+version: 3.10.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "3.10.1"
+appVersion: "3.10.2"
 
 maintainers:
   - name: API7

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -98,7 +98,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.httpRouter | string | `"radixtree_host_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
 | apisix.image.pullPolicy | string | `"Always"` | API7 Gateway image pull policy |
 | apisix.image.repository | string | `"api7/api7-ee-3-gateway"` | API7 Gateway image repository |
-| apisix.image.tag | string | `"3.10.1"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
+| apisix.image.tag | string | `"3.10.2"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
 | apisix.kind | string | `"Deployment"` | Use a `DaemonSet` or `Deployment` |
 | apisix.lru | object | `{"secret":{"count":512,"neg_count":512,"neg_ttl":60,"ttl":300}}` | fine tune the parameters of LRU cache for some features like secret |
 | apisix.lru.secret.neg_ttl | int | `60` | in seconds |

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -95,6 +95,12 @@ data:
           {{- if hasKey . "tls" }}
             tls: {{ .tls }}
           {{- end }}
+          {{- if hasKey . "proxy_protocol" }}
+            proxy_protocol: {{ .proxy_protocol }}
+          {{- end }}
+          {{- if hasKey . "proxy_protocol_to_upstream" }}
+            proxy_protocol_to_upstream: {{ .proxy_protocol_to_upstream }}
+          {{- end }}
           {{- else if kindIs "string" . }}
           - {{ . | quote }}
           {{- else }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -137,7 +137,7 @@ apisix:
     pullPolicy: Always
     # -- API7 Gateway image tag
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.10.1
+    tag: 3.10.2
 
   # -- Use a `DaemonSet` or `Deployment`
   kind: Deployment
@@ -370,6 +370,10 @@ gateway:
       # - addr: "3000-3100"             # port range in table form
       # - addr: "127.0.0.1:4000-4100"   # address with port range
       #   tls: true
+      # - addr: 9100                        # per-port PROXY protocol overrides for this entry
+      #   proxy_protocol: true              # accept the PROXY protocol on this port only
+      #   proxy_protocol_to_upstream: true  # send the PROXY protocol to the upstream on this port only;
+      #                                     # both override the global apisix.proxyProtocol.enableTcpPP* defaults
     udp: []
       # - addr: 192.168.31.10:53
       # - addr: 5353


### PR DESCRIPTION
Release chart bump for API7 EE 3.10.2.

## Version bumps

- `charts/api7`: chart `version` 3.10.0 → 3.10.1, `appVersion` → 3.10.2; image tags (integrated dashboard, dp-manager, file-server, developer-portal) → `v3.10.2`
- `charts/gateway`: chart `version` 3.10.1 → 3.10.2, `appVersion` → 3.10.2; image tag → `3.10.2`

Chart `version` follows the per-line counter (decoupled from the app patch): the api7 and gateway charts advance independently on the 3.10 line.

## Structural sync

- `charts/gateway`: support per-port PROXY protocol on `stream_proxy.tcp` entries — each entry can now set `proxy_protocol` (accept) and `proxy_protocol_to_upstream` (send), overriding the global `apisix.proxyProtocol.enableTcpPP*` defaults. Mirrors the gateway 3.10.2 config-default change.

READMEs regenerated with `make helm-docs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-TCP-entry proxy protocol settings in gateway stream configuration, allowing more flexible TCP upstream behavior.

* **Updates**
  * Bumped chart and application versions for API7 and Gateway.
  * Updated default container image tags to the latest release across chart values.

* **Documentation**
  * Refreshed Helm chart README files to match the new versions and default image tags.
  * Added configuration guidance for overriding TCP proxy protocol defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->