### PR TITLE
ci: bump actions off deprecated Node.js 12/16 runtimes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,10 +57,10 @@ jobs:
               '
 
       - name: Setup Kubernetes
-        uses: engineerd/setup-kind@v0.5.0
+        uses: helm/kind-action@v1
         with:
           version: v0.22.0
-          image: kindest/node:v1.31.0
+          node_image: kindest/node:v1.31.0
 
       - name: Test install charts
         run: |
@@ -94,7 +94,7 @@ jobs:
                   --charts charts/gateway --helm-extra-set-args "--set etcd.enabled=true --set apisix.extraEnvVars[0].name=API7_SKIP_FIRST_HEARTBEAT_DEBUG --set-string apisix.extraEnvVars[0].value=true"'
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.23'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0


### PR DESCRIPTION
GitHub emits deprecation warnings for actions running on the Node.js 12/16 runtimes. This moves the affected actions onto supported Node 20+ runtimes.

| Action | Before | After |
|---|---|---|
| actions/checkout | v2 | v4 |
| actions/setup-go | v4 | v5 |
| engineerd/setup-kind | v0.5.0 | helm/kind-action@v1 |

`engineerd/setup-kind` is unmaintained and runs on Node 12; it's replaced with the maintained `helm/kind-action`. The kind version (`v0.22.0`) and node image (`kindest/node:v1.31.0`) are unchanged — only the input key `image` becomes `node_image`. `checkout` keeps `submodules: recursive` / `fetch-depth: 0`.