### PR TITLE
feat(gateway): expose more gateway config options and document all values

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.10.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.10.2
+version: 3.10.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -46,12 +46,17 @@ The command removes all the Kubernetes components associated with the chart and 
 | admin.externalIPs | list | `[]` | IPs for which nodes in the cluster will also accept traffic for the servic |
 | admin.ingress | object | `{"annotations":{},"enabled":false,"hosts":[{"host":"apisix-admin.local","paths":["/apisix"]}],"tls":[]}` | Using ingress access API7 Gateway admin service |
 | admin.ingress.annotations | object | `{}` | Ingress annotations |
+| admin.ingress.enabled | bool | `false` | Enable an Ingress resource in front of the Admin API service |
+| admin.ingress.hosts | list | `[{"host":"apisix-admin.local","paths":["/apisix"]}]` | Ingress host and path rules |
+| admin.ingress.tls | list | `[]` | Ingress TLS settings |
 | admin.ip | string | `"0.0.0.0"` | which ip to listen on for API7 Gateway admin API. Set to `"[::]"` when on IPv6 single stack |
 | admin.port | int | `9180` | which port to use for API7 Gateway admin API |
 | admin.servicePort | int | `9180` | Service port to use for API7 Gateway admin API |
 | admin.type | string | `"ClusterIP"` | admin service type |
 | api7ee.disable_upstream_healthcheck | bool | `false` | A global switch for healthcheck. Defaults to false. When set to true, it overrides all upstream healthcheck configurations and globally disabling healthchecks. |
-| api7ee.healthcheck_report_interval | int | `120` | healthcheck data report interval in seconds |
+| api7ee.healthcheck_report_interval | int | `120` | Interval in seconds at which the gateway reports upstream healthcheck data to the control plane |
+| api7ee.http_timeout | string | `"30s"` | HTTP timeout used while sending healthcheck and telemetry data to the control plane |
+| api7ee.raw_api_calls_upload_interval | int | `3600` | Interval in seconds at which raw API call data (used by the API usage feature) is uploaded to the control plane |
 | api7ee.status_endpoint.enabled | bool | `false` | When enabled, APISIX will provide `/status` and `/status/ready` endpoints, /status endpoint will return 200 status code if APISIX has successfully started and running correctly, /status/ready endpoint will return 503 status code if none of the configured etcd (dp_manager) are available. |
 | api7ee.status_endpoint.ip | string | `"0.0.0.0"` | The IP address and port on which the status endpoint will listen. |
 | api7ee.status_endpoint.port | int | `7085` | The port on which the status endpoint will listen. |
@@ -65,45 +70,24 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.enableServerTokens | bool | `true` | Whether the APISIX version number should be shown in Server header |
 | apisix.enabled | bool | `true` | Enable or disable API7 Gateway itself |
 | apisix.extraEnvVars | list | `[]` | extraEnvVars An array to add extra env vars e.g: extraEnvVars:   - name: FOO     value: "bar"   - name: FOO2     valueFrom:       secretKeyRef:         name: SECRET_NAME         key: KEY |
-| apisix.extraEnvVarsCM | string | `""` |  |
-| apisix.extraEnvVarsSecret | string | `""` |  |
-| apisix.extraLuaCPath | string | `""` |  |
-| apisix.extraLuaPath | string | `""` |  |
-| apisix.hostNetwork | bool | `false` |  |
-| apisix.http.luaSharedDict.access-tokens | string | `"1m"` |  |
-| apisix.http.luaSharedDict.balancer-ewma | string | `"10m"` |  |
-| apisix.http.luaSharedDict.balancer-ewma-last-touched-at | string | `"10m"` |  |
-| apisix.http.luaSharedDict.balancer-ewma-locks | string | `"10m"` |  |
-| apisix.http.luaSharedDict.cas-auth | string | `"10m"` |  |
-| apisix.http.luaSharedDict.discovery | string | `"1m"` |  |
-| apisix.http.luaSharedDict.etcd-cluster-health-check | string | `"10m"` |  |
-| apisix.http.luaSharedDict.internal-status | string | `"10m"` |  |
-| apisix.http.luaSharedDict.introspection | string | `"10m"` |  |
-| apisix.http.luaSharedDict.jwks | string | `"1m"` |  |
-| apisix.http.luaSharedDict.lrucache-lock | string | `"10m"` |  |
-| apisix.http.luaSharedDict.plugin-api-breaker | string | `"10m"` |  |
-| apisix.http.luaSharedDict.plugin-graphql-limit-count | string | `"10m"` |  |
-| apisix.http.luaSharedDict.plugin-graphql-limit-count-reset-header | string | `"10m"` |  |
-| apisix.http.luaSharedDict.plugin-limit-conn | string | `"10m"` |  |
-| apisix.http.luaSharedDict.plugin-limit-count | string | `"10m"` |  |
-| apisix.http.luaSharedDict.plugin-limit-count-advanced | string | `"10m"` |  |
-| apisix.http.luaSharedDict.plugin-limit-count-advanced-redis-cluster-slot-lock | string | `"1m"` |  |
-| apisix.http.luaSharedDict.plugin-limit-count-redis-cluster-slot-lock | string | `"1m"` |  |
-| apisix.http.luaSharedDict.plugin-limit-req | string | `"10m"` |  |
-| apisix.http.luaSharedDict.status_report | string | `"1m"` |  |
-| apisix.http.luaSharedDict.tars | string | `"1m"` |  |
-| apisix.http.luaSharedDict.tracing_buffer | string | `"10m"` |  |
-| apisix.http.luaSharedDict.upstream-healthcheck | string | `"10m"` |  |
-| apisix.http.luaSharedDict.worker-events | string | `"10m"` |  |
+| apisix.extraEnvVarsCM | string | `""` | Name of existing ConfigMap containing extra env vars |
+| apisix.extraEnvVarsSecret | string | `""` | Name of existing Secret containing extra env vars |
+| apisix.extraLuaCPath | string | `""` | Extend lua_package_cpath to load third party Lua C libraries |
+| apisix.extraLuaPath | string | `""` | Extend lua_package_path to load third party Lua code |
+| apisix.hostNetwork | bool | `false` | Use the host's network namespace |
+| apisix.http.luaSharedDict | object | `{"access-tokens":"1m","balancer-ewma":"10m","balancer-ewma-last-touched-at":"10m","balancer-ewma-locks":"10m","cas-auth":"10m","discovery":"1m","etcd-cluster-health-check":"10m","internal-status":"10m","introspection":"10m","jwks":"1m","lrucache-lock":"10m","plugin-ai-rate-limiting":"10m","plugin-ai-rate-limiting-reset-header":"10m","plugin-api-breaker":"10m","plugin-graphql-limit-count":"10m","plugin-graphql-limit-count-reset-header":"10m","plugin-limit-conn":"10m","plugin-limit-conn-redis-cluster-slot-lock":"1m","plugin-limit-count":"10m","plugin-limit-count-advanced":"10m","plugin-limit-count-advanced-redis-cluster-slot-lock":"1m","plugin-limit-count-redis-cluster-slot-lock":"1m","plugin-limit-req":"10m","plugin-limit-req-redis-cluster-slot-lock":"1m","status_report":"1m","tars":"1m","tracing_buffer":"10m","upstream-healthcheck":"10m","worker-events":"10m"}` | Shared dict settings for the HTTP subsystem |
 | apisix.httpRouter | string | `"radixtree_host_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
 | apisix.image.pullPolicy | string | `"Always"` | API7 Gateway image pull policy |
 | apisix.image.repository | string | `"api7/api7-ee-3-gateway"` | API7 Gateway image repository |
 | apisix.image.tag | string | `"3.10.2"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
 | apisix.kind | string | `"Deployment"` | Use a `DaemonSet` or `Deployment` |
 | apisix.lru | object | `{"secret":{"count":512,"neg_count":512,"neg_ttl":60,"ttl":300}}` | fine tune the parameters of LRU cache for some features like secret |
-| apisix.lru.secret.neg_ttl | int | `60` | in seconds |
-| apisix.lru.secret.ttl | int | `300` | in seconds |
-| apisix.meta.luaSharedDict.prometheus-metrics | string | `"15m"` |  |
+| apisix.lru.secret.count | int | `512` | Maximum number of cached secret values |
+| apisix.lru.secret.neg_count | int | `512` | Maximum number of cached negative (failed lookup) results |
+| apisix.lru.secret.neg_ttl | int | `60` | TTL in seconds for cached negative (failed lookup) results |
+| apisix.lru.secret.ttl | int | `300` | TTL in seconds for cached secret values |
+| apisix.maxPostArgsReadableSize | int | `64` | Cap (in MB) on the request body read when matching `post_arg.*` route predicates for JSON and multipart requests. Set to 0 to disable the limit. |
+| apisix.meta.luaSharedDict | object | `{"prometheus-metrics":"15m"}` | Shared dict settings for the `meta` context (used by both HTTP and stream subsystems) |
 | apisix.nodeSelector | object | `{}` | Node labels for API7 Gateway pod assignment |
 | apisix.normalizeURILikeServlet | bool | `false` | The URI normalization in servlet is a little different from the RFC's. See https://github.com/jakartaee/servlet/blob/master/spec/src/main/asciidoc/servlet-spec-body.adoc#352-uri-path-canonicalization, which is used under Tomcat. Turn this option on if you want to be compatible with servlet when matching URI path. |
 | apisix.podAnnotations | object | `{}` | Annotations to add to each pod |
@@ -114,31 +98,40 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.podLabels | object | `{}` | Labels to add to each pod |
 | apisix.podSecurityContext | object | `{}` | Set the securityContext for API7 Gateway pods |
 | apisix.priorityClassName | string | `""` | Set [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) for API7 Gateway pods |
-| apisix.proxyProtocol | object | `{"enableTcpPP":false,"enableTcpPPToUpstream":false}` | PROXY Protocol configuration. |
-| apisix.proxyProtocol.enableTcpPP | bool | `false` | Enable PROXY Protocol for TCP proxy. It works with gateway.stream.tcp. |
-| apisix.proxyProtocol.enableTcpPPToUpstream | bool | `false` | Send PROXY Protocol to the upstream server for TCP proxy. |
+| apisix.proxyCache | object | `{"cacheTtl":"10s","zones":[{"cache_levels":"1:2","disk_path":"/tmp/disk_cache_one","disk_size":"1G","memory_size":"50m","name":"disk_cache_one"},{"memory_size":"50m","name":"memory_cache"}]}` | Proxy caching configuration used by the proxy-cache plugin. |
+| apisix.proxyCache.cacheTtl | string | `"10s"` | The default caching time in disk if the upstream does not specify the cache time |
+| apisix.proxyCache.zones | list | `[{"cache_levels":"1:2","disk_path":"/tmp/disk_cache_one","disk_size":"1G","memory_size":"50m","name":"disk_cache_one"},{"memory_size":"50m","name":"memory_cache"}]` | The parameters of a cache. The `memory_size` field stores the cache index for the disk strategy and the cache content for the memory strategy; `disk_size`, `disk_path` and `cache_levels` only apply to the disk strategy. |
+| apisix.proxyProtocol | object | `{"enableTcpPP":false,"enableTcpPPToUpstream":false,"listenHttpPort":null,"listenHttpsPort":null}` | PROXY Protocol configuration. |
+| apisix.proxyProtocol.enableTcpPP | bool | `false` | Accept the PROXY Protocol on every gateway.stream.tcp port. Acts as the default; override per port with the `proxy_protocol` field on a gateway.stream.tcp entry. |
+| apisix.proxyProtocol.enableTcpPPToUpstream | bool | `false` | Send the PROXY Protocol to the upstream server on every gateway.stream.tcp port. Acts as the default; override per port with the `proxy_protocol_to_upstream` field on a gateway.stream.tcp entry. |
+| apisix.proxyProtocol.listenHttpPort | int | `nil` | The HTTP port that accepts the PROXY Protocol. It differs from `gateway.http` ports and `admin` port: this port only accepts HTTP requests carrying the PROXY Protocol, while the other ports only accept plain HTTP requests. If you enable the PROXY Protocol, you must use this port to receive HTTP requests with it. |
+| apisix.proxyProtocol.listenHttpsPort | int | `nil` | The HTTPS port that accepts the PROXY Protocol. |
 | apisix.replicaCount | int | `1` | kind is DaemonSet, replicaCount not become effective |
 | apisix.resources | object | `{}` | Set pod resource requests & limits |
 | apisix.securityContext | object | `{}` | Set the securityContext for API7 Gateway container |
 | apisix.setIDFromPodUID | bool | `false` | Use Pod metadata.uid as the APISIX id. |
-| apisix.stream.luaSharedDict.config-stream | string | `"5m"` |  |
-| apisix.stream.luaSharedDict.etcd-cluster-health-check-stream | string | `"10m"` |  |
-| apisix.stream.luaSharedDict.lrucache-lock-stream | string | `"10m"` |  |
-| apisix.stream.luaSharedDict.plugin-limit-conn-stream | string | `"10m"` |  |
-| apisix.stream.luaSharedDict.tars-stream | string | `"1m"` |  |
-| apisix.stream.luaSharedDict.worker-events-stream | string | `"10m"` |  |
+| apisix.showUpstreamStatusInResponseHeader | bool | `false` | When true, the upstream status is always written to the `X-APISIX-Upstream-Status` response header; when false, it is written only for 5xx responses |
+| apisix.stream.luaSharedDict | object | `{"config-stream":"5m","etcd-cluster-health-check-stream":"10m","lrucache-lock-stream":"10m","nacos-stream":"20m","plugin-limit-conn-stream":"10m","tars-stream":"1m","worker-events-stream":"10m"}` | Shared dict settings for the stream (L4 proxy) subsystem |
 | apisix.terminationGracePeriodSeconds | int | `30` | termination grace period for API7 Gateway pods |
 | apisix.timezone | string | `""` | timezone is the timezone where apisix uses. For example: "UTC" or "Asia/Shanghai" This value will be set on apisix container's environment variable TZ. You may need to set the timezone to be consistent with your local time zone, otherwise the apisix's logs may used to retrieve event maybe in wrong timezone. |
 | apisix.tolerations | list | `[]` | List of node taints to tolerate |
 | apisix.topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pod assignment https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/ The value is evaluated as a template |
 | apisix.tracing | bool | `false` | Enable comprehensive request lifecycle tracing (SSL/SNI, rewrite, access, header_filter, body_filter, and log). When disabled, OpenTelemetry collects only a single span per request. |
-| autoscaling.enabled | bool | `false` |  |
-| autoscaling.maxReplicas | int | `100` |  |
-| autoscaling.minReplicas | int | `1` |  |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
+| apisix.trustedAddresses | list | `[]` | List of IPs/CIDRs from which the gateway trusts the `X-Forwarded-*` headers passed in requests. CAUTION: when not configured, or when the request comes from an untrusted address, the gateway overrides `X-Forwarded-Proto/Host/Port` with trusted values and clears the `Forwarded` header. For `X-Forwarded-For`: when this list is configured and the request comes from an untrusted address, the header is reset so the upstream only sees the connection IP observed by the gateway; when not configured, it is preserved and the connection IP is appended (compatible default). |
+| autoscaling.enabled | bool | `false` | Enable HorizontalPodAutoscaler for the gateway (only when apisix.kind is Deployment) |
+| autoscaling.maxReplicas | int | `100` | Maximum number of gateway replicas |
+| autoscaling.minReplicas | int | `1` | Minimum number of gateway replicas |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Target average CPU utilization percentage that triggers scaling |
+| autoscaling.targetMemoryUtilizationPercentage | int | `80` | Target average memory utilization percentage that triggers scaling |
 | autoscaling.version | string | `"v2"` | HPA version, the value is "v2" or "v2beta1", default "v2" |
-| configurationSnippet | object | `{"httpAdmin":"","httpEnd":"","httpSrv":"","httpSrvLocation":"","httpStart":"","main":"","stream":""}` | Custom configuration snippet. |
+| configurationSnippet | object | `{"httpAdmin":"","httpEnd":"","httpSrv":"","httpSrvLocation":"","httpStart":"","main":"","stream":""}` | Custom nginx configuration snippets injected into the generated nginx.conf. As arbitrary configuration can be added here, it is your responsibility to make sure the snippets don't conflict with the configuration generated by the gateway. |
+| configurationSnippet.httpAdmin | string | `""` | Snippet added to the nginx `server` block that serves the Admin API |
+| configurationSnippet.httpEnd | string | `""` | Snippet added to the end of the nginx `http` block |
+| configurationSnippet.httpSrv | string | `""` | Snippet added to the nginx `server` block that proxies regular traffic |
+| configurationSnippet.httpSrvLocation | string | `""` | Snippet added to the `location` block of the nginx `server` block that proxies regular traffic |
+| configurationSnippet.httpStart | string | `""` | Snippet added to the beginning of the nginx `http` block |
+| configurationSnippet.main | string | `""` | Snippet added to the nginx `main` (top-level) block |
+| configurationSnippet.stream | string | `""` | Snippet added to the nginx `stream` block |
 | control.enabled | bool | `true` | Enable Control API |
 | control.ip | string | `"127.0.0.1"` | which ip to listen on for Control API |
 | control.port | int | `9090` | which port to use for Control API |
@@ -151,15 +144,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | deployment.fallback_cp | object | `{}` | use cloud storage as the fallback control plane |
 | discovery.enabled | bool | `false` | Enable or disable API7 Gateway integration service discovery |
 | discovery.registry | object | `{}` | Registry is the same to the one in APISIX [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L281), and refer to such file for more setting details. also refer to [this documentation for integration service discovery](https://apisix.apache.org/docs/apisix/discovery) |
-| dns.resolvers[0] | string | `"127.0.0.1"` |  |
-| dns.resolvers[1] | string | `"172.20.0.10"` |  |
-| dns.resolvers[2] | string | `"114.114.114.114"` |  |
-| dns.resolvers[3] | string | `"223.5.5.5"` |  |
-| dns.resolvers[4] | string | `"1.1.1.1"` |  |
-| dns.resolvers[5] | string | `"8.8.8.8"` |  |
-| dns.timeout | int | `5` |  |
-| dns.validity | int | `30` |  |
-| etcd | object | `{"auth":{"rbac":{"create":false,"rootPassword":""},"tls":{"certFilename":"","certKeyFilename":"","enabled":false,"existingSecret":"","sni":"","verify":false}},"enabled":false,"host":["http://etcd.host:2379"],"image":{"repository":"api7/etcd"},"password":"","prefix":"/apisix","replicaCount":3,"service":{"port":2379},"timeout":30,"user":""}` | etcd configuration use the FQDN address or the IP of the etcd |
+| dns.enableResolvSearchOpt | bool | `true` | Honor the `search` option in `/etc/resolv.conf` when resolving domain names |
+| dns.resolvers | list | `[]` | Nameservers used by the gateway to resolve upstream domain names. When empty (default), nameservers are read from `/etc/resolv.conf`, which is usually what you want inside Kubernetes |
+| dns.timeout | int | `5` | DNS resolver timeout in seconds |
+| dns.validity | int | `30` | Override the TTL in seconds of valid DNS records |
+| etcd | object | `{"auth":{"rbac":{"create":false,"rootPassword":""},"tls":{"certFilename":"","certKeyFilename":"","enabled":false,"existingSecret":"","sni":"","verify":false}},"enabled":false,"host":["http://etcd.host:2379"],"image":{"repository":"api7/etcd"},"password":"","prefix":"/apisix","replicaCount":3,"service":{"port":2379},"startupRetry":2,"timeout":30,"user":"","watchTimeout":50}` | etcd configuration use the FQDN address or the IP of the etcd |
 | etcd.auth | object | `{"rbac":{"create":false,"rootPassword":""},"tls":{"certFilename":"","certKeyFilename":"","enabled":false,"existingSecret":"","sni":"","verify":false}}` | if etcd.enabled is true, set more values of bitnami/etcd helm chart |
 | etcd.auth.rbac.create | bool | `false` | No authentication by default. Switch to enable RBAC authentication |
 | etcd.auth.rbac.rootPassword | string | `""` | root password for etcd. Requires etcd.auth.rbac.create to be true. |
@@ -171,37 +160,57 @@ The command removes all the Kubernetes components associated with the chart and 
 | etcd.auth.tls.verify | bool | `false` | whether to verify the etcd endpoint certificate when setup a TLS connection to etcd |
 | etcd.enabled | bool | `false` | install etcd(v3) by default, set false if do not want to install etcd(v3) together |
 | etcd.host | list | `["http://etcd.host:2379"]` | if etcd.enabled is false, use external etcd, support multiple address, if your etcd cluster enables TLS, please use https scheme, e.g. https://127.0.0.1:2379. |
+| etcd.image.repository | string | `"api7/etcd"` | etcd image repository, only used when etcd.enabled is true |
 | etcd.password | string | `""` | if etcd.enabled is false, password for external etcd. If etcd.enabled is true, use etcd.auth.rbac.rootPassword instead. |
 | etcd.prefix | string | `"/apisix"` | apisix configurations prefix |
+| etcd.replicaCount | int | `3` | Number of etcd replicas, only used when etcd.enabled is true |
+| etcd.service.port | int | `2379` | etcd client service port |
+| etcd.startupRetry | int | `2` | The number of retries to etcd during startup |
 | etcd.timeout | int | `30` | Set the timeout value in seconds for subsequent socket operations from apisix to etcd cluster |
 | etcd.user | string | `""` | if etcd.enabled is false, username for external etcd. If etcd.enabled is true, use etcd.auth.rbac.rootPassword instead. |
+| etcd.watchTimeout | int | `50` | Set the timeout value in seconds for watching etcd |
 | extraInitContainers | list | `[]` | Additional `initContainers`, See [Kubernetes initContainers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) for the detail. |
-| extraVolumeMounts | list | `[]` | Additional `volume`, See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the detail. |
+| extraVolumeMounts | list | `[]` | Additional `volumeMounts` for the gateway container, See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the detail. |
 | extraVolumes | list | `[]` | Additional `volume`, See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the detail. |
-| fullnameOverride | string | `""` |  |
+| fullnameOverride | string | `""` | String to fully override the chart fullname |
 | gateway.externalIPs | list | `[]` | IPs for which nodes in the cluster will also accept traffic for the servic annotations:   service.beta.kubernetes.io/aws-load-balancer-type: nlb |
-| gateway.externalTrafficPolicy | string | `"Cluster"` |  |
+| gateway.externalTrafficPolicy | string | `"Cluster"` | Setting how the Service route external traffic. If you want to keep the client source IP, you can set this to Local, ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip |
 | gateway.http | object | `{"additionalContainerPorts":[],"containerPort":9080,"enabled":true,"ip":"0.0.0.0","nodePort":null,"servicePort":80}` | API7 Gateway service settings for http |
 | gateway.http.additionalContainerPorts | list | `[]` | Support multiple http ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L24) |
+| gateway.http.containerPort | int | `9080` | Container port the gateway listens on for HTTP traffic |
+| gateway.http.enabled | bool | `true` | Enable plain HTTP listeners |
 | gateway.http.ip | string | `"0.0.0.0"` | which ip to listen on for API7 Gateway http service. |
 | gateway.http.nodePort | int | `nil` | The nodePort of kubernetes service, only used if gateway.type is NodePort. If not set, a random port will be assigned by Kubernetes. |
+| gateway.http.servicePort | int | `80` | Kubernetes service port for HTTP traffic |
 | gateway.ingress | object | `{"annotations":{},"enabled":false,"hosts":[{"host":"apisix.local","paths":[]}],"tls":[]}` | Using ingress access API7 Gateway service |
 | gateway.ingress.annotations | object | `{}` | Ingress annotations |
+| gateway.ingress.enabled | bool | `false` | Enable an Ingress resource in front of the gateway service |
+| gateway.ingress.hosts | list | `[{"host":"apisix.local","paths":[]}]` | Ingress host and path rules |
+| gateway.ingress.tls | list | `[]` | Ingress TLS settings |
 | gateway.labelsOverride | object | `{}` | Override default labels assigned to API7 Gateway gateway resources |
 | gateway.livenessProbe | object | `{}` | kubernetes liveness probe. |
 | gateway.readinessProbe | object | `{}` | kubernetes readiness probe, we will provide a probe based on tcpSocket to gateway's HTTP port by default. |
 | gateway.stream | object | `{"autoAssignNodePort":false,"enabled":false,"only":false,"tcp":[],"udp":[]}` | API7 Gateway service settings for stream. L4 proxy (TCP/UDP) |
 | gateway.stream.autoAssignNodePort | bool | `false` | Whether to set nodePort to the same value as the TCP/UDP port when gateway.type is NodePort, make sure the nodePort to be in the valid NodePort range of kubernetes service. |
-| gateway.tls | object | `{"additionalContainerPorts":[],"certCAFilename":"","containerPort":9443,"enabled":true,"existingCASecret":"","fallbackSNI":"","http2":{"enabled":true},"ip":"0.0.0.0","nodePort":null,"servicePort":443,"sslProtocols":"TLSv1.2 TLSv1.3"}` | API7 Gateway service settings for tls |
+| gateway.stream.enabled | bool | `false` | Enable the stream (L4 proxy) subsystem |
+| gateway.stream.only | bool | `false` | Use the stream proxy only, without enabling the HTTP subsystem |
+| gateway.tls | object | `{"additionalContainerPorts":[],"certCAFilename":"","containerPort":9443,"enabled":true,"existingCASecret":"","fallbackSNI":"","http2":{"enabled":true},"ip":"0.0.0.0","nodePort":null,"servicePort":443,"sslCiphers":"ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA","sslProtocols":"TLSv1.2 TLSv1.3","sslSessionTickets":false}` | API7 Gateway service settings for tls |
 | gateway.tls.additionalContainerPorts | list | `[]` | Support multiple https ports, See [Configuration](https://github.com/apache/apisix/blob/0bc65ea9acd726f79f80ae0abd8f50b7eb172e3d/conf/config-default.yaml#L99) |
 | gateway.tls.certCAFilename | string | `""` | Filename be used in the gateway.tls.existingCASecret |
+| gateway.tls.containerPort | int | `9443` | Container port the gateway listens on for HTTPS traffic |
+| gateway.tls.enabled | bool | `true` | Enable HTTPS listeners |
 | gateway.tls.existingCASecret | string | `""` | Specifies the name of Secret contains trusted CA certificates in the PEM format used to verify the certificate when APISIX needs to do SSL/TLS handshaking with external services (e.g. etcd) |
 | gateway.tls.fallbackSNI | string | `""` | If set this, when the client doesn't send SNI during handshake, the fallback SNI will be used instead |
+| gateway.tls.http2.enabled | bool | `true` | Enable HTTP/2 on the HTTPS listeners |
 | gateway.tls.ip | string | `"0.0.0.0"` | which ip to listen on for API7 Gateway https service. |
 | gateway.tls.nodePort | int | `nil` | The nodePort of kubernetes service, only used if gateway.type is NodePort. If not set, a random port will be assigned by Kubernetes. |
+| gateway.tls.servicePort | int | `443` | Kubernetes service port for HTTPS traffic |
+| gateway.tls.sslCiphers | string | `"ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA"` | TLS cipher suites allowed to use, in OpenSSL cipher list format |
 | gateway.tls.sslProtocols | string | `"TLSv1.2 TLSv1.3"` | TLS protocols allowed to use. |
+| gateway.tls.sslSessionTickets | bool | `false` | Enable or disable TLS session tickets. Disabled by default because session tickets defeat Perfect Forward Secrecy (see https://github.com/mozilla/server-side-tls/issues/135) |
 | gateway.type | string | `"NodePort"` | API7 Gateway service type for user access itself |
 | global.imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |
+| graphql.maxSize | int | `1048576` | The maximum size in bytes of GraphQL queries the gateway parses when matching routes by GraphQL attributes (default 1MiB) |
 | initContainer.image | string | `"busybox"` | Init container image |
 | initContainer.tag | float | `1.28` | Init container tag |
 | logs.accessLog | string | `"/dev/stdout"` | Access log path |
@@ -215,19 +224,32 @@ The command removes all the Kubernetes components associated with the chart and 
 | logs.stream.accessLogFormat | string | `"$remote_addr [$time_local] $protocol $status $bytes_sent $bytes_received $session_time"` | Stream access log format |
 | logs.stream.accessLogFormatEscape | string | `"default"` | Allows setting json or default characters escaping in variables for stream |
 | logs.stream.enableAccessLog | bool | `false` | Enable stream access log or not, default false |
-| nameOverride | string | `""` |  |
-| nginx.enableCPUAffinity | bool | `true` |  |
-| nginx.envs | list | `[]` |  |
-| nginx.http | object | `{"clientBodyTimeout":"60s","clientHeaderTimeout":"60s","clientMaxBodySize":0,"keepaliveTimeout":"60s","sendTimeout":"10s"}` | HTTP timeout configurations |
+| nameOverride | string | `""` | String to partially override the chart fullname |
+| nginx.enableCPUAffinity | bool | `true` | Bind nginx worker processes to CPUs |
+| nginx.envs | list | `[]` | List of environment variable names allowed to be accessed within nginx (rendered as nginx `env` directives) |
+| nginx.http | object | `{"charset":"utf-8","clientBodyTimeout":"60s","clientHeaderTimeout":"60s","clientMaxBodySize":0,"keepaliveTimeout":"60s","proxySslServerName":true,"realIpFrom":["127.0.0.1","unix:"],"realIpHeader":"X-Real-IP","realIpRecursive":"off","sendTimeout":"10s","underscoresInHeaders":"on","upstream":{"keepalive":320,"keepaliveRequests":1000,"keepaliveTimeout":"60s"},"variablesHashMaxSize":2048}` | Nginx HTTP subsystem configurations |
+| nginx.http.charset | string | `"utf-8"` | The charset added to the "Content-Type" response header field, see [charset](http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset) |
 | nginx.http.clientBodyTimeout | string | `"60s"` | timeout for reading client request body, then 408 (Request Time-out) error is returned to the client |
 | nginx.http.clientHeaderTimeout | string | `"60s"` | timeout for reading client request header, then 408 (Request Time-out) error is returned to the client |
 | nginx.http.clientMaxBodySize | int | `0` | The maximum allowed size of the client request body. If exceeded, the 413 (Request Entity Too Large) error is returned to the client. Note that unlike Nginx, we don't limit the body size by default (0 means no limit). |
 | nginx.http.keepaliveTimeout | string | `"60s"` | timeout during which a keep-alive client connection will stay open on the server side |
+| nginx.http.proxySslServerName | bool | `true` | Enables or disables passing of the server name through TLS Server Name Indication extension (SNI, RFC 6066) when establishing a connection with the proxied HTTPS server |
+| nginx.http.realIpFrom | list | `["127.0.0.1","unix:"]` | Trusted addresses from which the real IP header is honored, see [set_real_ip_from](http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from) |
+| nginx.http.realIpHeader | string | `"X-Real-IP"` | The request header used to determine the client's real IP address, see [real_ip_header](http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header) |
+| nginx.http.realIpRecursive | string | `"off"` | Whether to search for the real IP recursively when the header set in nginx.http.realIpHeader contains multiple addresses, see [real_ip_recursive](http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive) |
 | nginx.http.sendTimeout | string | `"10s"` | timeout for transmitting a response to the client, then the connection is closed |
-| nginx.workerConnections | string | `"10620"` |  |
-| nginx.workerProcesses | string | `"auto"` |  |
-| nginx.workerRlimitNofile | string | `"20480"` |  |
-| nginx.workerShutdownTimeout | string | `"240s"` |  |
+| nginx.http.underscoresInHeaders | string | `"on"` | Enable the use of underscores in client request header fields |
+| nginx.http.upstream | object | `{"keepalive":320,"keepaliveRequests":1000,"keepaliveTimeout":"60s"}` | Keepalive settings for connections from the gateway to upstream servers |
+| nginx.http.upstream.keepalive | int | `320` | Maximum number of idle keepalive connections to upstream servers that are preserved in the cache of each worker process. When this number is exceeded, the least recently used connections are closed |
+| nginx.http.upstream.keepaliveRequests | int | `1000` | Maximum number of requests that can be served through one keepalive connection. After the maximum number of requests is made, the connection is closed |
+| nginx.http.upstream.keepaliveTimeout | string | `"60s"` | Timeout during which an idle keepalive connection to an upstream server will stay open |
+| nginx.http.variablesHashMaxSize | int | `2048` | The maximum size of the nginx variables hash table |
+| nginx.maxPendingTimers | int | `16384` | Maximum number of pending timers. Increase it if you see "too many pending timers" error |
+| nginx.maxRunningTimers | int | `4096` | Maximum number of running timers. Increase it if you see "lua_max_running_timers are not enough" error |
+| nginx.workerConnections | string | `"10620"` | The maximum number of connections that each worker process can open |
+| nginx.workerProcesses | string | `"auto"` | The number of nginx worker processes. `auto` means the number of CPU cores |
+| nginx.workerRlimitNofile | string | `"20480"` | The number of files a worker process can open, should be larger than nginx.workerConnections |
+| nginx.workerShutdownTimeout | string | `"240s"` | Timeout for a graceful shutdown of worker processes |
 | openapiToMcp.enabled | bool | `false` | Enable or disable the OpenAPI-to-MCP sidecar. Required when using the `openapi-to-mcp` or `mcp-tools-acl` plugins. The container runs alongside the gateway in the same pod and is reached on 127.0.0.1. |
 | openapiToMcp.image.pullPolicy | string | `"IfNotPresent"` | OpenAPI-to-MCP image pull policy |
 | openapiToMcp.image.repository | string | `"api7/openapi-to-mcp"` | OpenAPI-to-MCP image repository |
@@ -235,10 +257,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | openapiToMcp.port | int | `3000` | Port that the sidecar listens on. Must match the `port` configured under `plugin_attr.openapi-to-mcp` in the gateway config (defaults to 3000). |
 | openapiToMcp.resources | object | `{}` | Resources for the OpenAPI-to-MCP sidecar container. |
 | pluginAttrs | object | `{}` | Set APISIX plugin attributes, see [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L376) for more details |
-| rbac.create | bool | `false` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `false` |  |
-| serviceAccount.name | string | `""` |  |
+| rbac.create | bool | `false` | Whether RBAC resources (ClusterRole and ClusterRoleBinding) should be created |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount |
+| serviceAccount.create | bool | `false` | Whether a ServiceAccount should be created for the gateway pods |
+| serviceAccount.name | string | `""` | Name of the ServiceAccount to use. If not set and create is true, a name is generated from the chart fullname |
 | serviceMonitor | object | `{"annotations":{},"containerPort":9091,"enabled":false,"interval":"15s","labels":{},"metricPrefix":"apisix_","name":"","namespace":"","nodePort":null,"path":"/apisix/prometheus/metrics"}` | Observability configuration. ref: https://apisix.apache.org/docs/apisix/plugins/prometheus/ |
 | serviceMonitor.annotations | object | `{}` | @param serviceMonitor.annotations ServiceMonitor annotations |
 | serviceMonitor.containerPort | int | `9091` | container port where the metrics are exposed |
@@ -254,7 +276,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | soapProxy.image.pullPolicy | string | `"IfNotPresent"` | SOAP proxy image pull policy |
 | soapProxy.image.repository | string | `"api7/soap-proxy"` | SOAP proxy image repository |
 | soapProxy.image.tag | string | `"1.0.0"` | SOAP proxy image tag |
-| updateStrategy | object | `{}` |  |
+| updateStrategy | object | `{}` | Update strategy of the workload (Deployment or DaemonSet), e.g. `type: RollingUpdate` |
 | vault.enabled | bool | `false` | Enable or disable the vault integration |
 | vault.host | string | `""` | The host address where the vault server is running. |
 | vault.prefix | string | `""` | Prefix allows you to better enforcement of policies. |

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -41,36 +41,31 @@ data:
       enable_reuseport: true                       # Enable nginx SO_REUSEPORT switch if set to true.
       enable_ipv6: {{ .Values.apisix.enableIPv6 }} # Enable nginx IPv6 resolver
       enable_server_tokens: {{ .Values.apisix.enableServerTokens }} # Whether the APISIX version number should be shown in Server header
+      show_upstream_status_in_response_header: {{ .Values.apisix.showUpstreamStatusInResponseHeader }} # when true all upstream status write to `X-APISIX-Upstream-Status` otherwise only 5xx code
 
-      {{- if or .Values.apisix.proxyProtocol.enableTcpPP .Values.apisix.proxyProtocol.enableTcpPPToUpstream }}
+      {{- with .Values.apisix.trustedAddresses }}
+      trusted_addresses:    # When configured, APISIX will trust the `X-Forwarded-*` Headers passed in requests from the IP/CIDR in the list.
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      max_post_args_readable_size: {{ .Values.apisix.maxPostArgsReadableSize }} # Cap (in MB) on the request body read when matching `post_arg.*` route predicates
+
+      {{- if or .Values.apisix.proxyProtocol.enableTcpPP .Values.apisix.proxyProtocol.enableTcpPPToUpstream .Values.apisix.proxyProtocol.listenHttpPort .Values.apisix.proxyProtocol.listenHttpsPort }}
       proxy_protocol:
+        {{- if .Values.apisix.proxyProtocol.listenHttpPort }}
+        listen_http_port: {{ .Values.apisix.proxyProtocol.listenHttpPort }}
+        {{- end }}
+        {{- if .Values.apisix.proxyProtocol.listenHttpsPort }}
+        listen_https_port: {{ .Values.apisix.proxyProtocol.listenHttpsPort }}
+        {{- end }}
         enable_tcp_pp: {{ .Values.apisix.proxyProtocol.enableTcpPP }}
         enable_tcp_pp_to_upstream: {{ .Values.apisix.proxyProtocol.enableTcpPPToUpstream }}
       {{- end }}
 
-      # proxy_protocol:                   # Proxy Protocol configuration
-      #   listen_http_port: 9181          # The port with proxy protocol for http, it differs from node_listen and admin_listen.
-      #                                   # This port can only receive http request with proxy protocol, but node_listen & admin_listen
-      #                                   # can only receive http request. If you enable proxy protocol, you must use this port to
-      #                                   # receive http request with proxy protocol
-      #   listen_https_port: 9182         # The port with proxy protocol for https
-      #   enable_tcp_pp: true             # Enable the proxy protocol for tcp proxy, it works for stream_proxy.tcp option
-      #   enable_tcp_pp_to_upstream: true # Enables the proxy protocol to the upstream server
-
       proxy_cache:                         # Proxy Caching configuration
-        cache_ttl: 10s                     # The default caching time if the upstream does not specify the cache time
+        cache_ttl: {{ .Values.apisix.proxyCache.cacheTtl }} # The default caching time if the upstream does not specify the cache time
         zones:                             # The parameters of a cache
-        - name: disk_cache_one             # The name of the cache, administrator can be specify
-                                           # which cache to use by name in the admin api
-          memory_size: 50m                 # The size of shared memory, it's used to store the cache index
-          disk_size: 1G                    # The size of disk, it's used to store the cache data
-          disk_path: "/tmp/disk_cache_one" # The path to store the cache data
-          cache_levels: "1:2"              # The hierarchy levels of a cache
-      #  - name: disk_cache_two
-      #    memory_size: 50m
-      #    disk_size: 1G
-      #    disk_path: "/tmp/disk_cache_two"
-      #    cache_levels: "1:2"
+          {{- toYaml .Values.apisix.proxyCache.zones | nindent 10 }}
 
       delete_uri_tail_slash: {{ .Values.apisix.deleteURITailSlash }}    # delete the '/' at the end of the URI
       # The URI normalization in servlet is a little different from the RFC's.
@@ -121,12 +116,15 @@ data:
           {{- end }}
         {{- end }}
       {{- end }}
-      # dns_resolver:
-      #   {{- range $resolver := .Values.dns.resolvers }}
-      #   - {{ $resolver }}
-      #   {{- end }}
+      {{- with .Values.dns.resolvers }}
+      dns_resolver:    # If not set, read from `/etc/resolv.conf`
+        {{- range $resolver := . }}
+        - {{ $resolver }}
+        {{- end }}
+      {{- end }}
       dns_resolver_valid: {{.Values.dns.validity}}
       resolver_timeout: {{.Values.dns.timeout}}
+      enable_resolv_search_opt: {{ .Values.dns.enableResolvSearchOpt }}
       ssl:
         enable: {{ .Values.gateway.tls.enabled }}
         listen:
@@ -140,7 +138,8 @@ data:
           {{- toYaml . | nindent 10}}
           {{- end }}
         ssl_protocols: {{ .Values.gateway.tls.sslProtocols | quote }}
-        ssl_ciphers: "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA"
+        ssl_ciphers: {{ .Values.gateway.tls.sslCiphers | quote }}
+        ssl_session_tickets: {{ .Values.gateway.tls.sslSessionTickets }}
         {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.existingCASecret }}
         ssl_trusted_certificate: "system,/usr/local/apisix/conf/ssl/{{ .Values.gateway.tls.certCAFilename }}"
         {{- end }}
@@ -180,6 +179,8 @@ data:
       enable_cpu_affinity: {{ and true .Values.nginx.enableCPUAffinity }}
       worker_rlimit_nofile: {{ default "20480" .Values.nginx.workerRlimitNofile }}  # the number of files a worker process can open, should be larger than worker_connections
       worker_shutdown_timeout: "{{ .Values.nginx.workerShutdownTimeout }}"
+      max_pending_timers: {{ default "16384" .Values.nginx.maxPendingTimers }}   # increase it if you see "too many pending timers" error
+      max_running_timers: {{ default "4096" .Values.nginx.maxRunningTimers }}    # increase it if you see "lua_max_running_timers are not enough" error
       event:
         worker_connections: {{ default "10620" .Values.nginx.workerConnections  }}
       {{- with .Values.nginx.envs }}
@@ -230,11 +231,20 @@ data:
         client_max_body_size: {{ .Values.nginx.http.clientMaxBodySize }}        # The maximum allowed size of the client request body.
                                        # If exceeded, the 413 (Request Entity Too Large) error is returned to the client.
                                        # Note that unlike Nginx, we don't limit the body size by default.
-        underscores_in_headers: "on"   # default enables the use of underscores in client request header fields
-        real_ip_header: "X-Real-IP"    # http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
+        underscores_in_headers: {{ .Values.nginx.http.underscoresInHeaders | quote }}   # default enables the use of underscores in client request header fields
+        real_ip_header: {{ .Values.nginx.http.realIpHeader | quote }}    # http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header
+        real_ip_recursive: {{ .Values.nginx.http.realIpRecursive | quote }}    # http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive
         real_ip_from:                  # http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from
-          - 127.0.0.1
-          - 'unix:'
+          {{- range $ip := .Values.nginx.http.realIpFrom }}
+          - {{ $ip | quote }}
+          {{- end }}
+        proxy_ssl_server_name: {{ .Values.nginx.http.proxySslServerName }}  # send the server name (SNI) when establishing a TLS connection with the proxied HTTPS upstream
+        upstream:
+          keepalive: {{ .Values.nginx.http.upstream.keepalive }}                     # The maximum number of idle keepalive connections to upstream servers per worker process
+          keepalive_requests: {{ .Values.nginx.http.upstream.keepaliveRequests }}    # The maximum number of requests that can be served through one keepalive connection
+          keepalive_timeout: {{ .Values.nginx.http.upstream.keepaliveTimeout }}      # Timeout during which an idle keepalive connection to an upstream server will stay open
+        charset: {{ .Values.nginx.http.charset }}    # Adds the specified charset to the "Content-Type" response header field
+        variables_hash_max_size: {{ .Values.nginx.http.variablesHashMaxSize }}    # Sets the maximum size of the variables hash table
         {{- if .Values.apisix.customLuaSharedDicts }}
         custom_lua_shared_dict:        # add custom shared cache to nginx.conf
         {{- range $dict := .Values.apisix.customLuaSharedDicts }}
@@ -266,6 +276,9 @@ data:
       {{- if .Values.configurationSnippet.stream }}
       stream_configuration_snippet: {{- toYaml .Values.configurationSnippet.stream | indent 6 }}
       {{- end }}
+
+    graphql:
+      max_size: {{ int .Values.graphql.maxSize }}    # the maximum size limitation of graphql in bytes
 
     {{- if .Values.discovery.enabled }}
     discovery:
@@ -359,7 +372,9 @@ data:
           {{- end}}
       {{- end }}
         prefix: {{ .Values.etcd.prefix | quote }}    # configuration prefix in etcd
-        timeout: {{ .Values.etcd.timeout }}    # 30 seconds
+        timeout: {{ .Values.etcd.timeout }}    # The timeout in seconds when connect/read/write to etcd
+        watch_timeout: {{ .Values.etcd.watchTimeout }}    # The timeout in seconds when watch etcd
+        startup_retry: {{ .Values.etcd.startupRetry }}    # the number of retry to etcd during the startup
         {{- if and (not .Values.etcd.enabled) .Values.etcd.user }}
         user: {{ .Values.etcd.user | quote }}
         password: {{ .Values.etcd.password | quote }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -7,8 +7,14 @@ global:
   imagePullSecrets: []
 
 api7ee:
-  # -- healthcheck data report interval in seconds
+  # -- Interval in seconds at which the gateway reports upstream healthcheck data to the control plane
   healthcheck_report_interval: 120
+
+  # -- Interval in seconds at which raw API call data (used by the API usage feature) is uploaded to the control plane
+  raw_api_calls_upload_interval: 3600
+
+  # -- HTTP timeout used while sending healthcheck and telemetry data to the control plane
+  http_timeout: 30s
 
   status_endpoint:
     # -- When enabled, APISIX will provide `/status` and `/status/ready` endpoints, /status endpoint will return 200 status code if APISIX has successfully started and running correctly, /status/ready endpoint will return 503 status code if none of the configured etcd (dp_manager) are available.
@@ -31,21 +37,64 @@ apisix:
   # -- Whether the APISIX version number should be shown in Server header
   enableServerTokens: true
 
+  # -- When true, the upstream status is always written to the `X-APISIX-Upstream-Status` response header; when false, it is written only for 5xx responses
+  showUpstreamStatusInResponseHeader: false
+
+  # -- List of IPs/CIDRs from which the gateway trusts the `X-Forwarded-*` headers passed in requests.
+  # CAUTION: when not configured, or when the request comes from an untrusted address, the gateway
+  # overrides `X-Forwarded-Proto/Host/Port` with trusted values and clears the `Forwarded` header.
+  # For `X-Forwarded-For`: when this list is configured and the request comes from an untrusted address,
+  # the header is reset so the upstream only sees the connection IP observed by the gateway; when not
+  # configured, it is preserved and the connection IP is appended (compatible default).
+  trustedAddresses: []
+    # - 127.0.0.1
+    # - 172.18.0.0/16
+
+  # -- Cap (in MB) on the request body read when matching `post_arg.*` route predicates
+  # for JSON and multipart requests. Set to 0 to disable the limit.
+  maxPostArgsReadableSize: 64
+
   # -- PROXY Protocol configuration.
   proxyProtocol:
-    # -- Enable PROXY Protocol for TCP proxy. It works with gateway.stream.tcp.
+    # -- (int) The HTTP port that accepts the PROXY Protocol. It differs from `gateway.http` ports and `admin` port:
+    # this port only accepts HTTP requests carrying the PROXY Protocol, while the other ports only accept plain HTTP
+    # requests. If you enable the PROXY Protocol, you must use this port to receive HTTP requests with it.
+    listenHttpPort:
+    # -- (int) The HTTPS port that accepts the PROXY Protocol.
+    listenHttpsPort:
+    # -- Accept the PROXY Protocol on every gateway.stream.tcp port. Acts as the default;
+    # override per port with the `proxy_protocol` field on a gateway.stream.tcp entry.
     enableTcpPP: false
-    # -- Send PROXY Protocol to the upstream server for TCP proxy.
+    # -- Send the PROXY Protocol to the upstream server on every gateway.stream.tcp port. Acts as the default;
+    # override per port with the `proxy_protocol_to_upstream` field on a gateway.stream.tcp entry.
     enableTcpPPToUpstream: false
 
   # -- Use Pod metadata.uid as the APISIX id.
   setIDFromPodUID: false
 
+  # -- Proxy caching configuration used by the proxy-cache plugin.
+  proxyCache:
+    # -- The default caching time in disk if the upstream does not specify the cache time
+    cacheTtl: 10s
+    # -- The parameters of a cache. The `memory_size` field stores the cache index for the
+    # disk strategy and the cache content for the memory strategy; `disk_size`, `disk_path`
+    # and `cache_levels` only apply to the disk strategy.
+    zones:
+      - name: disk_cache_one
+        memory_size: 50m
+        disk_size: 1G
+        disk_path: "/tmp/disk_cache_one"
+        cache_levels: "1:2"
+      - name: memory_cache
+        memory_size: 50m
+
   meta:
+    # -- Shared dict settings for the `meta` context (used by both HTTP and stream subsystems)
     luaSharedDict:
       prometheus-metrics: 15m
 
   stream:
+    # -- Shared dict settings for the stream (L4 proxy) subsystem
     luaSharedDict:
       etcd-cluster-health-check-stream: 10m
       lrucache-lock-stream: 10m
@@ -53,21 +102,27 @@ apisix:
       worker-events-stream: 10m
       tars-stream: 1m
       config-stream: 5m
+      nacos-stream: 20m
 
   http:
+    # -- Shared dict settings for the HTTP subsystem
     luaSharedDict:
       internal-status: 10m
       plugin-limit-req: 10m
       plugin-limit-count: 10m
       plugin-limit-conn: 10m
+      plugin-limit-conn-redis-cluster-slot-lock: 1m
       plugin-graphql-limit-count: 10m
       plugin-graphql-limit-count-reset-header: 10m
+      plugin-ai-rate-limiting: 10m
+      plugin-ai-rate-limiting-reset-header: 10m
       upstream-healthcheck: 10m
       worker-events: 10m
       lrucache-lock: 10m
       balancer-ewma: 10m
       balancer-ewma-locks: 10m
       balancer-ewma-last-touched-at: 10m
+      plugin-limit-req-redis-cluster-slot-lock: 1m
       plugin-limit-count-redis-cluster-slot-lock: 1m
       plugin-limit-count-advanced: 10m
       plugin-limit-count-advanced-redis-cluster-slot-lock: 1m
@@ -85,11 +140,13 @@ apisix:
   # -- fine tune the parameters of LRU cache for some features like secret
   lru:
     secret:
-      # -- in seconds
+      # -- TTL in seconds for cached secret values
       ttl: 300
+      # -- Maximum number of cached secret values
       count: 512
-      # -- in seconds
+      # -- TTL in seconds for cached negative (failed lookup) results
       neg_ttl: 60
+      # -- Maximum number of cached negative (failed lookup) results
       neg_count: 512
 
   # -- Enable comprehensive request lifecycle tracing (SSL/SNI, rewrite, access, header_filter, body_filter, and log).
@@ -108,7 +165,9 @@ apisix:
     # - name: bar
     #   size: 1m
 
+  # -- Extend lua_package_path to load third party Lua code
   extraLuaPath: ""
+  # -- Extend lua_package_cpath to load third party Lua C libraries
   extraLuaCPath: ""
 
   # -- Delete the '/' at the end of the URI
@@ -183,8 +242,6 @@ apisix:
 
   # -- Set pod resource requests & limits
   resources: {}
-    # -- Use the host's network namespace
-
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -195,6 +252,8 @@ apisix:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+
+  # -- Use the host's network namespace
   hostNetwork: false
 
   # -- Custom DNS settings for the APISIX pods
@@ -225,22 +284,26 @@ apisix:
   #         name: SECRET_NAME
   #         key: KEY
   extraEnvVars: []
-  ## @param extraEnvVarsCM Name of existing ConfigMap containing extra env vars
-  ##
+  # -- Name of existing ConfigMap containing extra env vars
   extraEnvVarsCM: ""
-  ## @param extraEnvVarsSecret Name of existing Secret containing extra env vars
-  ##
+  # -- Name of existing Secret containing extra env vars
   extraEnvVarsSecret: ""
 
+# -- String to partially override the chart fullname
 nameOverride: ""
+# -- String to fully override the chart fullname
 fullnameOverride: ""
 
 serviceAccount:
+  # -- Whether a ServiceAccount should be created for the gateway pods
   create: false
+  # -- Annotations to add to the ServiceAccount
   annotations: {}
+  # -- Name of the ServiceAccount to use. If not set and create is true, a name is generated from the chart fullname
   name: ""
 
 rbac:
+  # -- Whether RBAC resources (ClusterRole and ClusterRoleBinding) should be created
   create: false
 
 deployment:
@@ -286,9 +349,8 @@ deployment:
 gateway:
   # -- API7 Gateway service type for user access itself
   type: NodePort
-  # -- Setting how the Service route external traffic
-  # If you want to keep the client source IP, you can set this to Local.
-
+  # -- Setting how the Service route external traffic.
+  # If you want to keep the client source IP, you can set this to Local,
   # ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   externalTrafficPolicy: Cluster
   # type: LoadBalancer
@@ -306,10 +368,13 @@ gateway:
   livenessProbe: {}
   # -- API7 Gateway service settings for http
   http:
+    # -- Enable plain HTTP listeners
     enabled: true
     # -- which ip to listen on for API7 Gateway http service.
     ip: 0.0.0.0
+    # -- Kubernetes service port for HTTP traffic
     servicePort: 80
+    # -- Container port the gateway listens on for HTTP traffic
     containerPort: 9080
     # -- (int) The nodePort of kubernetes service, only used if gateway.type is NodePort. If not set, a random port will be assigned by Kubernetes.
     nodePort:
@@ -329,10 +394,13 @@ gateway:
       #   backlog: 1024
   # -- API7 Gateway service settings for tls
   tls:
+    # -- Enable HTTPS listeners
     enabled: true
     # -- which ip to listen on for API7 Gateway https service.
     ip: 0.0.0.0
+    # -- Kubernetes service port for HTTPS traffic
     servicePort: 443
+    # -- Container port the gateway listens on for HTTPS traffic
     containerPort: 9443
     # -- (int) The nodePort of kubernetes service, only used if gateway.type is NodePort. If not set, a random port will be assigned by Kubernetes.
     nodePort:
@@ -351,14 +419,22 @@ gateway:
     # -- Filename be used in the gateway.tls.existingCASecret
     certCAFilename: ""
     http2:
+      # -- Enable HTTP/2 on the HTTPS listeners
       enabled: true
     # -- TLS protocols allowed to use.
     sslProtocols: "TLSv1.2 TLSv1.3"
+    # -- TLS cipher suites allowed to use, in OpenSSL cipher list format
+    sslCiphers: "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA"
+    # -- Enable or disable TLS session tickets. Disabled by default because session tickets
+    # defeat Perfect Forward Secrecy (see https://github.com/mozilla/server-side-tls/issues/135)
+    sslSessionTickets: false
     # -- If set this, when the client doesn't send SNI during handshake, the fallback SNI will be used instead
     fallbackSNI: ""
   # -- API7 Gateway service settings for stream. L4 proxy (TCP/UDP)
   stream:
+    # -- Enable the stream (L4 proxy) subsystem
     enabled: false
+    # -- Use the stream proxy only, without enabling the HTTP subsystem
     only: false
     # -- Whether to set nodePort to the same value as the TCP/UDP port when gateway.type is NodePort, make sure the nodePort to be in the valid NodePort range of kubernetes service.
     autoAssignNodePort: false
@@ -381,14 +457,17 @@ gateway:
       # - "9300-9310"                   # port range
   # -- Using ingress access API7 Gateway service
   ingress:
+    # -- Enable an Ingress resource in front of the gateway service
     enabled: false
     # -- Ingress annotations
     annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+    # -- Ingress host and path rules
     hosts:
       - host: apisix.local
         paths: []
+    # -- Ingress TLS settings
     tls: []
   #  - secretName: apisix-tls
   #    hosts:
@@ -434,29 +513,42 @@ admin:
       - 127.0.0.1/24
   # -- Using ingress access API7 Gateway admin service
   ingress:
+    # -- Enable an Ingress resource in front of the Admin API service
     enabled: false
     # -- Ingress annotations
     annotations:
       {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+    # -- Ingress host and path rules
     hosts:
       - host: apisix-admin.local
         paths:
           - "/apisix"
+    # -- Ingress TLS settings
     tls: []
   #  - secretName: apisix-tls
   #    hosts:
   #      - chart-example.local
 
 nginx:
+  # -- The number of files a worker process can open, should be larger than nginx.workerConnections
   workerRlimitNofile: "20480"
+  # -- Timeout for a graceful shutdown of worker processes
   workerShutdownTimeout: "240s"
+  # -- The maximum number of connections that each worker process can open
   workerConnections: "10620"
+  # -- The number of nginx worker processes. `auto` means the number of CPU cores
   workerProcesses: auto
+  # -- Bind nginx worker processes to CPUs
   enableCPUAffinity: true
+  # -- Maximum number of pending timers. Increase it if you see "too many pending timers" error
+  maxPendingTimers: 16384
+  # -- Maximum number of running timers. Increase it if you see "lua_max_running_timers are not enough" error
+  maxRunningTimers: 4096
+  # -- List of environment variable names allowed to be accessed within nginx (rendered as nginx `env` directives)
   envs: []
-  # -- HTTP timeout configurations
+  # -- Nginx HTTP subsystem configurations
   http:
     # -- timeout during which a keep-alive client connection will stay open on the server side
     keepaliveTimeout: "60s"
@@ -470,10 +562,46 @@ nginx:
     # If exceeded, the 413 (Request Entity Too Large) error is returned to the client.
     # Note that unlike Nginx, we don't limit the body size by default (0 means no limit).
     clientMaxBodySize: 0
+    # -- Enable the use of underscores in client request header fields
+    underscoresInHeaders: "on"
+    # -- The request header used to determine the client's real IP address,
+    # see [real_ip_header](http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header)
+    realIpHeader: "X-Real-IP"
+    # -- Whether to search for the real IP recursively when the header set in nginx.http.realIpHeader contains multiple addresses,
+    # see [real_ip_recursive](http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive)
+    realIpRecursive: "off"
+    # -- Trusted addresses from which the real IP header is honored,
+    # see [set_real_ip_from](http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from)
+    realIpFrom:
+      - 127.0.0.1
+      - "unix:"
+    # -- Enables or disables passing of the server name through TLS Server Name Indication extension (SNI, RFC 6066)
+    # when establishing a connection with the proxied HTTPS server
+    proxySslServerName: true
+    # -- Keepalive settings for connections from the gateway to upstream servers
+    upstream:
+      # -- Maximum number of idle keepalive connections to upstream servers that are preserved in the cache of each worker process.
+      # When this number is exceeded, the least recently used connections are closed
+      keepalive: 320
+      # -- Maximum number of requests that can be served through one keepalive connection.
+      # After the maximum number of requests is made, the connection is closed
+      keepaliveRequests: 1000
+      # -- Timeout during which an idle keepalive connection to an upstream server will stay open
+      keepaliveTimeout: 60s
+    # -- The charset added to the "Content-Type" response header field,
+    # see [charset](http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset)
+    charset: utf-8
+    # -- The maximum size of the nginx variables hash table
+    variablesHashMaxSize: 2048
 
 # -- Set APISIX plugin attributes, see [config-default.yaml](https://github.com/apache/apisix/blob/master/conf/config-default.yaml#L376) for more details
 pluginAttrs: {}
 
+graphql:
+  # -- The maximum size in bytes of GraphQL queries the gateway parses when matching routes by GraphQL attributes (default 1MiB)
+  maxSize: 1048576
+
+# -- Update strategy of the workload (Deployment or DaemonSet), e.g. `type: RollingUpdate`
 updateStrategy: {}
   # type: RollingUpdate
 
@@ -482,7 +610,7 @@ extraVolumes: []
 # - name: extras
 #   emptyDir: {}
 
-# -- Additional `volume`, See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the detail.
+# -- Additional `volumeMounts` for the gateway container, See [Kubernetes Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) for the detail.
 extraVolumeMounts: []
 # - name: extras
 #   mountPath: /usr/share/extras
@@ -547,15 +675,18 @@ logs:
     accessLogFormatEscape: default
 
 dns:
-  resolvers:
-    - 127.0.0.1
-    - 172.20.0.10
-    - 114.114.114.114
-    - 223.5.5.5
-    - 1.1.1.1
-    - 8.8.8.8
+  # -- Nameservers used by the gateway to resolve upstream domain names.
+  # When empty (default), nameservers are read from `/etc/resolv.conf`,
+  # which is usually what you want inside Kubernetes
+  resolvers: []
+    # - 127.0.0.1
+    # - 8.8.8.8
+  # -- Override the TTL in seconds of valid DNS records
   validity: 30
+  # -- DNS resolver timeout in seconds
   timeout: 5
+  # -- Honor the `search` option in `/etc/resolv.conf` when resolving domain names
+  enableResolvSearchOpt: true
 
 initContainer:
   # -- Init container image
@@ -564,28 +695,42 @@ initContainer:
   tag: 1.28
 
 autoscaling:
+  # -- Enable HorizontalPodAutoscaler for the gateway (only when apisix.kind is Deployment)
   enabled: false
   # -- HPA version, the value is "v2" or "v2beta1", default "v2"
   version: v2
+  # -- Minimum number of gateway replicas
   minReplicas: 1
+  # -- Maximum number of gateway replicas
   maxReplicas: 100
+  # -- Target average CPU utilization percentage that triggers scaling
   targetCPUUtilizationPercentage: 80
+  # -- Target average memory utilization percentage that triggers scaling
   targetMemoryUtilizationPercentage: 80
 
-# -- Custom configuration snippet.
+# -- Custom nginx configuration snippets injected into the generated nginx.conf.
+# As arbitrary configuration can be added here, it is your responsibility to make sure
+# the snippets don't conflict with the configuration generated by the gateway.
 configurationSnippet:
+  # -- Snippet added to the nginx `main` (top-level) block
   main: |
 
+  # -- Snippet added to the beginning of the nginx `http` block
   httpStart: |
 
+  # -- Snippet added to the end of the nginx `http` block
   httpEnd: |
 
+  # -- Snippet added to the nginx `server` block that proxies regular traffic
   httpSrv: |
 
+  # -- Snippet added to the `location` block of the nginx `server` block that proxies regular traffic
   httpSrvLocation: |
 
+  # -- Snippet added to the nginx `server` block that serves the Admin API
   httpAdmin: |
 
+  # -- Snippet added to the nginx `stream` block
   stream: |
 
 # -- Observability configuration.
@@ -618,6 +763,7 @@ etcd:
   # -- install etcd(v3) by default, set false if do not want to install etcd(v3) together
   enabled: false
   image:
+    # -- etcd image repository, only used when etcd.enabled is true
     repository: api7/etcd
   # -- if etcd.enabled is false, use external etcd, support multiple address, if your etcd cluster enables TLS, please use https scheme, e.g. https://127.0.0.1:2379.
   host:
@@ -631,6 +777,10 @@ etcd:
   prefix: "/apisix"
   # -- Set the timeout value in seconds for subsequent socket operations from apisix to etcd cluster
   timeout: 30
+  # -- Set the timeout value in seconds for watching etcd
+  watchTimeout: 50
+  # -- The number of retries to etcd during startup
+  startupRetry: 2
 
   # -- if etcd.enabled is true, set more values of bitnami/etcd helm chart
   auth:
@@ -654,8 +804,10 @@ etcd:
       sni: ""
 
   service:
+    # -- etcd client service port
     port: 2379
 
+  # -- Number of etcd replicas, only used when etcd.enabled is true
   replicaCount: 3
 
 vault:


### PR DESCRIPTION
## What this PR does

Compares the gateway chart against the gateway's `config-default.yaml` and exposes the config options that were previously not configurable through the chart:

**`apisix` level**
- `apisix.showUpstreamStatusInResponseHeader` → `show_upstream_status_in_response_header`
- `apisix.trustedAddresses` → `trusted_addresses` (trust `X-Forwarded-*` headers from these IPs/CIDRs)
- `apisix.maxPostArgsReadableSize` → `max_post_args_readable_size`
- `apisix.proxyProtocol.listenHttpPort` / `listenHttpsPort` → PROXY protocol HTTP/HTTPS listen ports (previously only the TCP toggles were exposed)
- `apisix.proxyCache` → `proxy_cache` was hardcoded in the configmap; now configurable, and the default zones include the `memory_cache` zone from the gateway defaults (previously the hardcoded block dropped it, which broke the `proxy-cache` plugin's memory strategy)
- `dns.resolvers` → `dns_resolver` (the template previously had this commented out, so the existing value was silently ignored; the default is now `[]` = read `/etc/resolv.conf`, which keeps current behavior)
- `dns.enableResolvSearchOpt` → `enable_resolv_search_opt`
- `gateway.tls.sslCiphers` → `ssl_ciphers` (was hardcoded; default unchanged)
- `gateway.tls.sslSessionTickets` → `ssl_session_tickets`

**`nginx_config` level**
- `nginx.maxPendingTimers` / `maxRunningTimers`
- `nginx.http.underscoresInHeaders`, `realIpHeader`, `realIpRecursive`, `realIpFrom` (previously hardcoded; `real_ip_recursive` was not rendered at all)
- `nginx.http.proxySslServerName`, `charset`, `variablesHashMaxSize`
- `nginx.http.upstream.keepalive` / `keepaliveRequests` / `keepaliveTimeout`
- sync `lua_shared_dict` defaults with the gateway (`nacos-stream`, `plugin-ai-rate-limiting*`, redis-cluster slot locks)

**others**
- `graphql.maxSize` → `graphql.max_size`
- `etcd.watchTimeout` / `startupRetry` → `deployment.etcd.watch_timeout` / `startup_retry`
- `api7ee.raw_api_calls_upload_interval`, `api7ee.http_timeout`

Options that the control plane manages and delivers to the DP via the heartbeat config payload are intentionally **not** exposed: `data_encryption`, `ssl.key_encrypt_salt`, `api7ee.consumer_proxy` / `developer_proxy` / `telemetry`, dynamic service discovery (`api7_discovery`), and the enabled plugin list.

Every value in `values.yaml` now carries a helm-docs description (previously ~60 parameters rendered with an empty description column), so the generated README fully documents the chart. README regenerated with helm-docs; gateway chart version bumped to 3.10.3.

## Compatibility

All new values default to the gateway's `config-default.yaml` defaults, so a rendered config with default values is unchanged except for the `proxy_cache` `memory_cache` zone noted above. Verified by rendering the chart (default values and a variant with the new options set) and running `apisix init` config validation against the `api7-ee-3-gateway:3.10.2` image.