### PR TITLE
release(aisix-cp): 0.3.0

### DIFF
--- a/charts/aisix-cp/Chart.yaml
+++ b/charts/aisix-cp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix-cp
 description: Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"
 
 maintainers:
   - name: API7

--- a/charts/aisix-cp/README.md
+++ b/charts/aisix-cp/README.md
@@ -1,6 +1,6 @@
 # aisix-cp
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
 
 Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 
@@ -98,6 +98,10 @@ Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| twoDSN.enabled | bool | `false` |  |
+| twoDSN.existingSecret | string | `""` |  |
+| twoDSN.existingSecretKey | string | `"serving-password"` |  |
+| twoDSN.servingPassword | string | `""` |  |
 | ui.affinity | object | `{}` |  |
 | ui.defaultLocale | string | `"en"` |  |
 | ui.extraEnvVars | list | `[]` |  |

--- a/charts/aisix-cp/templates/_helpers.tpl
+++ b/charts/aisix-cp/templates/_helpers.tpl
@@ -119,6 +119,37 @@ postgres://{{ include "aisix-cp.pgUser" . }}:$(PGPASSWORD)@{{ include "aisix-cp.
 {{- end }}
 
 {{/*
+Serving database URL for two-DSN mode: same host/port/db, but connecting
+as the non-superuser cp_api_app role. Uses $(SERVING_PGPASSWORD) env-var
+substitution for runtime secret injection.
+*/}}
+{{- define "aisix-cp.servingDatabaseURL" -}}
+postgres://cp_api_app:$(SERVING_PGPASSWORD)@{{ include "aisix-cp.pgHost" . }}:{{ include "aisix-cp.pgPort" . }}/{{ include "aisix-cp.pgDatabase" . }}?sslmode={{ include "aisix-cp.pgSSLMode" . }}
+{{- end }}
+
+{{/*
+Name of the Secret holding the cp_api_app serving-role password.
+*/}}
+{{- define "aisix-cp.servingPasswordSecretName" -}}
+{{- if .Values.twoDSN.existingSecret }}
+{{- .Values.twoDSN.existingSecret }}
+{{- else }}
+{{- include "aisix-cp.secretName" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Secret key holding the cp_api_app serving-role password.
+*/}}
+{{- define "aisix-cp.servingPasswordSecretKey" -}}
+{{- if .Values.twoDSN.existingSecret }}
+{{- .Values.twoDSN.existingSecretKey | default "serving-password" }}
+{{- else }}
+{{- "serving-password" }}
+{{- end }}
+{{- end }}
+
+{{/*
 Secret name for aisix-cp secrets.
 */}}
 {{- define "aisix-cp.secretName" -}}

--- a/charts/aisix-cp/templates/api-deployment.yaml
+++ b/charts/aisix-cp/templates/api-deployment.yaml
@@ -42,10 +42,24 @@ spec:
                 secretKeyRef:
                   name: {{ include "aisix-cp.pgSecretName" . }}
                   key: {{ include "aisix-cp.pgPasswordSecretKey" . }}
+            {{- if .Values.twoDSN.enabled }}
+            - name: SERVING_PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "aisix-cp.servingPasswordSecretName" . }}
+                  key: {{ include "aisix-cp.servingPasswordSecretKey" . }}
+            {{- end }}
             - name: AISIX_CLOUD_LISTEN
               value: ":8080"
+            {{- if .Values.twoDSN.enabled }}
+            - name: AISIX_CLOUD_ADMIN_DATABASE_URL
+              value: {{ include "aisix-cp.databaseURL" . }}
+            - name: AISIX_CLOUD_DATABASE_URL
+              value: {{ include "aisix-cp.servingDatabaseURL" . }}
+            {{- else }}
             - name: AISIX_CLOUD_DATABASE_URL
               value: {{ include "aisix-cp.databaseURL" . }}
+            {{- end }}
             - name: AISIX_CLOUD_PUBLIC_BASE_URL
               value: {{ .Values.api.publicBaseURL | quote }}
             - name: AISIX_CLOUD_MASTER_KEY

--- a/charts/aisix-cp/templates/secret.yaml
+++ b/charts/aisix-cp/templates/secret.yaml
@@ -23,6 +23,16 @@ password. Skipped when an existingSecret injects the credentials.
     {{- end }}
   {{- end }}
 {{- end }}
+{{/*
+Two-DSN serving-role password: when chart-managed (no existingSecret),
+hold it to the same standard as the app secrets above so cp_api_app can't
+be provisioned with an empty/placeholder login.
+*/}}
+{{- if and .Values.twoDSN.enabled (not .Values.twoDSN.existingSecret) }}
+  {{- if or (eq .Values.twoDSN.servingPassword "") (hasPrefix "CHANGE_ME" .Values.twoDSN.servingPassword) }}
+    {{- fail "twoDSN.servingPassword must be set to a real password when twoDSN.enabled=true (generate a URL-safe one with: openssl rand -hex 24) — or inject it via twoDSN.existingSecret." }}
+  {{- end }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -35,3 +45,6 @@ type: Opaque
 data:
   master-key: {{ .Values.secrets.masterKey | b64enc }}
   better-auth-secret: {{ .Values.secrets.betterAuthSecret | b64enc }}
+  {{- if and .Values.twoDSN.enabled (not .Values.twoDSN.existingSecret) }}
+  serving-password: {{ .Values.twoDSN.servingPassword | b64enc }}
+  {{- end }}

--- a/charts/aisix-cp/values.yaml
+++ b/charts/aisix-cp/values.yaml
@@ -191,3 +191,28 @@ externalDatabase:
   ## If existingSecret is empty, this password is used directly.
   password: ""
   sslmode: disable
+
+## @section Two-DSN tenant isolation (SaaS / multi-tenant only)
+## When enabled, cp-api opens TWO pools against the same database:
+##   - an admin pool on the privileged DSN above (builtin postgres or the
+##     externalDatabase user) that runs migrations + the cross-tenant paths;
+##   - a serving pool that connects AS the non-superuser `cp_api_app` role,
+##     so every tenant query is Row-Level-Security filtered and a path that
+##     forgets to scope fails closed (zero rows) instead of leaking.
+## cp-api provisions cp_api_app's LOGIN + password (from servingPassword)
+## on the admin pool at boot — you do NOT pre-create the role.
+##
+## Leave DISABLED for single-tenant / private (OP) deployments: there every
+## org is one trust domain, RLS is inert, and the single privileged DSN
+## handles everything (the current default behavior). See the internal
+## docs/rls-architecture.md for the full model.
+twoDSN:
+  enabled: false
+  ## Password cp-api assigns to the cp_api_app serving role and uses in the
+  ## serving DSN. Required when enabled unless existingSecret is set.
+  ## Use a URL-safe value (no + / =): it is embedded in a postgres:// DSN.
+  servingPassword: ""
+  ## Optionally source the serving password from an existing Secret instead
+  ## of servingPassword above. Key defaults to "serving-password".
+  existingSecret: ""
+  existingSecretKey: "serving-password"


### PR DESCRIPTION
Bump `charts/aisix-cp` to **0.3.0** (`version` + `appVersion`) and sync the dev-cycle chart deltas from the CP source-of-truth chart (`AISIX-Cloud/helm/aisix-cp`).

Synced delta — **two-DSN tenant isolation** support (AISIX-Cloud#931):
- new `twoDSN.*` values block (`enabled`, `servingPassword`, `existingSecret`, `existingSecretKey`), disabled by default
- `_helpers.tpl`: `servingDatabaseURL` + serving-password secret name/key helpers
- `secret.yaml`: chart-managed `serving-password` entry with the same placeholder-rejection validation as the other secrets
- `api-deployment.yaml`: when enabled, splits `AISIX_CLOUD_ADMIN_DATABASE_URL` (privileged) from `AISIX_CLOUD_DATABASE_URL` (non-superuser `cp_api_app`) and injects `SERVING_PGPASSWORD`; with it disabled the rendered manifests are unchanged from 0.2.0 apart from the image tags

Preserves the public adaptations: `docker.io` registries, image `tag: ""` → `.Chart.AppVersion`, the always-emitted `api.dpImage` default, and the public README (regenerated via helm-docs).

App images `docker.io/api7/aisix:0.3.0` and `docker.io/api7/aisix-cp-{api,dpm,ui}:0.3.0` are already published, so `appVersion` resolves to existing tags. Merging publishes `aisix-cp-0.3.0` to charts.api7.ai.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional support for separate admin and serving database connections.
  * Introduced new configuration options for enabling this mode and providing serving credentials.

* **Bug Fixes**
  * Added validation to prevent missing or placeholder serving passwords when the new mode is enabled.

* **Documentation**
  * Updated chart version information and documented the new configuration options in the Helm chart guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->