### PR TITLE
release(aisix-cp): 0.3.1

### DIFF
--- a/charts/aisix-cp/Chart.yaml
+++ b/charts/aisix-cp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix-cp
 description: Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.3.1
+appVersion: "0.3.1"
 
 maintainers:
   - name: API7

--- a/charts/aisix-cp/README.md
+++ b/charts/aisix-cp/README.md
@@ -1,6 +1,6 @@
 # aisix-cp
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.1](https://img.shields.io/badge/AppVersion-0.3.1-informational?style=flat-square)
 
 Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 
@@ -29,6 +29,7 @@ Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 | api.image.tag | string | `""` |  |
 | api.nodeSelector | object | `{}` |  |
 | api.oauthEnabled | bool | `false` |  |
+| api.playgroundAllowPrivateIPs | bool | `false` |  |
 | api.podSecurityContext.fsGroup | int | `101` |  |
 | api.podSecurityContext.runAsGroup | int | `101` |  |
 | api.podSecurityContext.runAsNonRoot | bool | `true` |  |

--- a/charts/aisix-cp/templates/api-deployment.yaml
+++ b/charts/aisix-cp/templates/api-deployment.yaml
@@ -77,6 +77,10 @@ spec:
             {{- end }}
             - name: AISIX_CLOUD_OAUTH_ENABLED
               value: {{ .Values.api.oauthEnabled | quote }}
+            {{- if .Values.api.playgroundAllowPrivateIPs }}
+            - name: AISIX_PLAYGROUND_ALLOW_PRIVATE_IPS
+              value: "1"
+            {{- end }}
             - name: AISIX_CLOUD_DP_IMAGE
               value: {{ .Values.api.dpImage | default (printf "docker.io/api7/aisix:%s" .Chart.AppVersion) | quote }}
             {{- with .Values.api.extraEnvVars }}

--- a/charts/aisix-cp/values.yaml
+++ b/charts/aisix-cp/values.yaml
@@ -41,6 +41,11 @@ api:
   dpmgrBaseURL: ""
   oauthEnabled: false
   dpImage: ""  # empty -> docker.io/api7/aisix:<appVersion>
+  ## Allow the dashboard playground to reach LLM endpoints on private /
+  ## internal networks. cp-api blocks private IPs by default (SSRF guard);
+  ## enable this only for self-hosted deployments whose models live on an
+  ## internal network the cp-api pod can route to.
+  playgroundAllowPrivateIPs: false
 
 ## @section dp-manager
 dpm:


### PR DESCRIPTION
Release-time sync of the `aisix-cp` chart for the 0.3.1 OP version. Bumps `version` and `appVersion` to 0.3.1 and syncs the accumulated CP source-of-truth chart delta into the public chart.

## Changes
- **Bump** `version` and `appVersion` `0.3.0` → `0.3.1`. `appVersion` pins the published `docker.io/api7/aisix-cp-{api,dpm,ui}:0.3.1` and `docker.io/api7/aisix:0.3.1` images (already on Docker Hub).
- **Sync** `api.playgroundAllowPrivateIPs` → `AISIX_PLAYGROUND_ALLOW_PRIVATE_IPS` env on the cp-api deployment. Lets the dashboard playground reach LLM endpoints on private/internal networks in self-hosted installs (cp-api blocks private IPs by default as an SSRF guard); `false` by default, so existing installs are unaffected.
- Regenerated `README.md` (helm-docs).

Preserves the public adaptations by design: `docker.io/*` registries, `tag: ""` → `.Chart.AppVersion`, `dpImage` default → `docker.io/api7/aisix:<appVersion>`, and the public `README.md`. After the sync the only residual diff vs the CP chart is exactly those adaptations.

Merging publishes `aisix-cp-0.3.1` to https://charts.api7.ai.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to allow the playground to access private IP endpoints when needed.

* **Documentation**
  * Updated chart documentation and version badges to reflect the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->