### PR TITLE
feat: raise shared memory defaults on the 3.9.x chart line

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.9.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.9.2
+version: 3.9.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -56,7 +56,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | api7ee.status_endpoint.ip | string | `"0.0.0.0"` | The IP address and port on which the status endpoint will listen. |
 | api7ee.status_endpoint.port | int | `7085` | The port on which the status endpoint will listen. |
 | apisix.affinity | object | `{}` | Set affinity for API7 Gateway deploy |
-| apisix.customLuaSharedDicts | list | `[]` | Add custom [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings, click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict |
+| apisix.customLuaSharedDicts | list | `[{"name":"kubernetes","size":"64m"},{"name":"nacos","size":"64m"},{"name":"consul","size":"64m"}]` | Add custom [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings, click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict |
 | apisix.customizedConfig | object | `{}` | If apisix.enableCustomizedConfig is true, full customized config.yaml. Please note that other settings about APISIX config will be ignored |
 | apisix.deleteURITailSlash | bool | `false` | Delete the '/' at the end of the URI |
 | apisix.dnsConfig | object | `{}` | Custom DNS settings for the APISIX pods |
@@ -71,6 +71,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.extraLuaPath | string | `""` |  |
 | apisix.hostNetwork | bool | `false` |  |
 | apisix.http.luaSharedDict.access-tokens | string | `"1m"` |  |
+| apisix.http.luaSharedDict.api-calls-for-portal | string | `"64m"` |  |
 | apisix.http.luaSharedDict.balancer-ewma | string | `"10m"` |  |
 | apisix.http.luaSharedDict.balancer-ewma-last-touched-at | string | `"10m"` |  |
 | apisix.http.luaSharedDict.balancer-ewma-locks | string | `"10m"` |  |
@@ -92,7 +93,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.http.luaSharedDict.plugin-limit-req | string | `"10m"` |  |
 | apisix.http.luaSharedDict.status_report | string | `"1m"` |  |
 | apisix.http.luaSharedDict.tars | string | `"1m"` |  |
-| apisix.http.luaSharedDict.tracing_buffer | string | `"10m"` |  |
+| apisix.http.luaSharedDict.tracing_buffer | string | `"32m"` |  |
 | apisix.http.luaSharedDict.upstream-healthcheck | string | `"10m"` |  |
 | apisix.http.luaSharedDict.worker-events | string | `"10m"` |  |
 | apisix.httpRouter | string | `"radixtree_host_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
@@ -103,7 +104,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.lru | object | `{"secret":{"count":512,"neg_count":512,"neg_ttl":60,"ttl":300}}` | fine tune the parameters of LRU cache for some features like secret |
 | apisix.lru.secret.neg_ttl | int | `60` | in seconds |
 | apisix.lru.secret.ttl | int | `300` | in seconds |
-| apisix.meta.luaSharedDict.prometheus-metrics | string | `"15m"` |  |
+| apisix.meta.luaSharedDict.prometheus-metrics | string | `"256m"` |  |
 | apisix.nodeSelector | object | `{}` | Node labels for API7 Gateway pod assignment |
 | apisix.normalizeURILikeServlet | bool | `false` | The URI normalization in servlet is a little different from the RFC's. See https://github.com/jakartaee/servlet/blob/master/spec/src/main/asciidoc/servlet-spec-body.adoc#352-uri-path-canonicalization, which is used under Tomcat. Turn this option on if you want to be compatible with servlet when matching URI path. |
 | apisix.podAnnotations | object | `{}` | Annotations to add to each pod |

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -36,7 +36,7 @@ apisix:
 
   meta:
     luaSharedDict:
-      prometheus-metrics: 15m
+      prometheus-metrics: 256m
 
   stream:
     luaSharedDict:
@@ -64,7 +64,7 @@ apisix:
       plugin-limit-count-redis-cluster-slot-lock: 1m
       plugin-limit-count-advanced: 10m
       plugin-limit-count-advanced-redis-cluster-slot-lock: 1m
-      tracing_buffer: 10m
+      tracing_buffer: 32m
       plugin-api-breaker: 10m
       etcd-cluster-health-check: 10m
       discovery: 1m
@@ -74,6 +74,7 @@ apisix:
       tars: 1m
       cas-auth: 10m
       status_report: 1m
+      api-calls-for-portal: 64m
 
   # -- fine tune the parameters of LRU cache for some features like secret
   lru:
@@ -91,15 +92,15 @@ apisix:
 
   # -- Add custom [lua_shared_dict](https://github.com/openresty/lua-nginx-module#toc88) settings,
   # click [here](https://github.com/apache/apisix-helm-chart/blob/master/charts/apisix/values.yaml#L27-L30) to learn the format of a shared dict
-  customLuaSharedDicts: []
-    # - name: kubernetes
-    #   size: 20m
-    # - name: nacos
-    #   size: 20m
+  customLuaSharedDicts:
+    - name: kubernetes
+      size: 64m
+    - name: nacos
+      size: 64m
+    - name: consul
+      size: 64m
     # - name: foo
     #   size: 10k
-    # - name: bar
-    #   size: 1m
 
   extraLuaPath: ""
   extraLuaCPath: ""


### PR DESCRIPTION
Raise the non-evictable shared-memory defaults on the 3.9.x chart line, mirroring #310 (which does the same for the 3.10.x line on \`main\`).

These zones drop data when full rather than evicting, so their defaults are sized for typical deployments instead of the old minimal values:

- \`prometheus-metrics\` 15m → 256m
- \`tracing_buffer\` 10m → 32m
- \`api-calls-for-portal\` added at 64m (Developer Portal API-usage counters)
- \`customLuaSharedDicts\` seeds \`kubernetes\` / \`nacos\` / \`consul\` service discovery at 64m each

Any of these can still be overridden through the chart values. Gateway chart bumped 3.9.2 → 3.9.3.

\`nacos-stream\` does not exist on the 3.9.x line, so it is left untouched (unlike #310).

Fixes api7/api7-ee-3-gateway#1869