### PR TITLE
fix(gateway): reduce prometheus shared dict to 128m

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.10.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.10.5
+version: 3.10.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -87,7 +87,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.lru.secret.neg_ttl | int | `60` | TTL in seconds for cached negative (failed lookup) results |
 | apisix.lru.secret.ttl | int | `300` | TTL in seconds for cached secret values |
 | apisix.maxPostArgsReadableSize | int | `64` | Cap (in MB) on the request body read when matching `post_arg.*` route predicates for JSON and multipart requests. Set to 0 to disable the limit. |
-| apisix.meta.luaSharedDict | object | `{"prometheus-metrics":"256m"}` | Shared dict settings for the `meta` context (used by both HTTP and stream subsystems) |
+| apisix.meta.luaSharedDict | object | `{"prometheus-metrics":"128m"}` | Shared dict settings for the `meta` context (used by both HTTP and stream subsystems) |
 | apisix.nodeSelector | object | `{}` | Node labels for API7 Gateway pod assignment |
 | apisix.normalizeURILikeServlet | bool | `false` | The URI normalization in servlet is a little different from the RFC's. See https://github.com/jakartaee/servlet/blob/master/spec/src/main/asciidoc/servlet-spec-body.adoc#352-uri-path-canonicalization, which is used under Tomcat. Turn this option on if you want to be compatible with servlet when matching URI path. |
 | apisix.podAnnotations | object | `{}` | Annotations to add to each pod |

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -99,7 +99,7 @@ apisix:
   meta:
     # -- Shared dict settings for the `meta` context (used by both HTTP and stream subsystems)
     luaSharedDict:
-      prometheus-metrics: 256m
+      prometheus-metrics: 128m
 
   stream:
     # -- Shared dict settings for the stream (L4 proxy) subsystem


### PR DESCRIPTION
Reduce the default gateway Prometheus shared dictionary from 256m to 128m on the 3.10 chart line.

This also bumps the gateway chart patch version to 3.10.6 so the updated default can be published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Gateway Helm chart version to 3.10.6.

* **Configuration**
  * Reduced the default Prometheus metrics shared-memory allocation from 256 MB to 128 MB.
  * Updated the chart documentation to reflect the new default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->