### PR TITLE
fix(gateway): reduce 3.9 prometheus shared dict to 128m

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.9.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.9.3
+version: 3.9.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -104,7 +104,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.lru | object | `{"secret":{"count":512,"neg_count":512,"neg_ttl":60,"ttl":300}}` | fine tune the parameters of LRU cache for some features like secret |
 | apisix.lru.secret.neg_ttl | int | `60` | in seconds |
 | apisix.lru.secret.ttl | int | `300` | in seconds |
-| apisix.meta.luaSharedDict.prometheus-metrics | string | `"256m"` |  |
+| apisix.meta.luaSharedDict.prometheus-metrics | string | `"128m"` |  |
 | apisix.nodeSelector | object | `{}` | Node labels for API7 Gateway pod assignment |
 | apisix.normalizeURILikeServlet | bool | `false` | The URI normalization in servlet is a little different from the RFC's. See https://github.com/jakartaee/servlet/blob/master/spec/src/main/asciidoc/servlet-spec-body.adoc#352-uri-path-canonicalization, which is used under Tomcat. Turn this option on if you want to be compatible with servlet when matching URI path. |
 | apisix.podAnnotations | object | `{}` | Annotations to add to each pod |

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -36,7 +36,7 @@ apisix:
 
   meta:
     luaSharedDict:
-      prometheus-metrics: 256m
+      prometheus-metrics: 128m
 
   stream:
     luaSharedDict:


### PR DESCRIPTION
Reduce the default gateway Prometheus shared dictionary from 256m to 128m on the 3.9 chart line.

This also bumps the gateway chart patch version to 3.9.4 so the updated default can be published.