### PR TITLE
chore: upgrade api7 and gateway to v3.9.16

### DIFF
--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.9.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.9.1
+version: 3.9.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.9.15"
+appVersion: "3.9.16"
 
 maintainers:
   - name: API7

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -1,6 +1,6 @@
 # api7ee3
 
-![Version: 3.9.1](https://img.shields.io/badge/Version-3.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.15](https://img.shields.io/badge/AppVersion-3.9.15-informational?style=flat-square)
+![Version: 3.9.2](https://img.shields.io/badge/Version-3.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.16](https://img.shields.io/badge/AppVersion-3.9.16-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -29,7 +29,7 @@ A Helm chart for Kubernetes
 | dashboard.extraVolumes | list | `[]` |  |
 | dashboard.image.pullPolicy | string | `"Always"` |  |
 | dashboard.image.repository | string | `"api7/api7-ee-3-integrated"` |  |
-| dashboard.image.tag | string | `"v3.9.15"` |  |
+| dashboard.image.tag | string | `"v3.9.16"` |  |
 | dashboard.keyCertSecret | string | `""` |  |
 | dashboard.livenessProbe.failureThreshold | int | `30` |  |
 | dashboard.livenessProbe.initialDelaySeconds | int | `180` |  |
@@ -120,7 +120,7 @@ A Helm chart for Kubernetes
 | developer_portal.extraVolumes | list | `[]` |  |
 | developer_portal.image.pullPolicy | string | `"Always"` |  |
 | developer_portal.image.repository | string | `"api7/api7-ee-developer-portal"` |  |
-| developer_portal.image.tag | string | `"v3.9.15"` |  |
+| developer_portal.image.tag | string | `"v3.9.16"` |  |
 | developer_portal.keyCertSecret | string | `""` |  |
 | developer_portal.livenessProbe.failureThreshold | int | `10` |  |
 | developer_portal.livenessProbe.initialDelaySeconds | int | `60` |  |
@@ -166,7 +166,7 @@ A Helm chart for Kubernetes
 | dp_manager.extraVolumes | list | `[]` |  |
 | dp_manager.image.pullPolicy | string | `"Always"` |  |
 | dp_manager.image.repository | string | `"api7/api7-ee-dp-manager"` |  |
-| dp_manager.image.tag | string | `"v3.9.15"` |  |
+| dp_manager.image.tag | string | `"v3.9.16"` |  |
 | dp_manager.livenessProbe.failureThreshold | int | `10` |  |
 | dp_manager.livenessProbe.initialDelaySeconds | int | `60` |  |
 | dp_manager.livenessProbe.periodSeconds | int | `3` |  |
@@ -232,7 +232,7 @@ A Helm chart for Kubernetes
 | file_server.enabled | bool | `false` |  |
 | file_server.image.pullPolicy | string | `"Always"` |  |
 | file_server.image.repository | string | `"api7/api7-ee-file-server"` |  |
-| file_server.image.tag | string | `"v3.9.15"` |  |
+| file_server.image.tag | string | `"v3.9.16"` |  |
 | file_server.livenessProbe.failureThreshold | int | `10` |  |
 | file_server.livenessProbe.initialDelaySeconds | int | `60` |  |
 | file_server.livenessProbe.periodSeconds | int | `3` |  |

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -18,7 +18,7 @@ dashboard:
     repository: api7/api7-ee-3-integrated
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.15"
+    tag: "v3.9.16"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -55,7 +55,7 @@ dp_manager:
     repository: api7/api7-ee-dp-manager
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.15"
+    tag: "v3.9.16"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -92,7 +92,7 @@ file_server:
   image:
     repository: api7/api7-ee-file-server
     pullPolicy: Always
-    tag: "v3.9.15"
+    tag: "v3.9.16"
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 3
@@ -110,7 +110,7 @@ developer_portal:
     repository: api7/api7-ee-developer-portal
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.15"
+    tag: "v3.9.16"
 
   extraEnvVars: []
   extraVolumes: []

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -16,12 +16,12 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.9.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.9.4
+version: 3.9.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "3.9.15"
+appVersion: "3.9.16"
 
 maintainers:
   - name: API7

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -99,11 +99,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.httpRouter | string | `"radixtree_host_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
 | apisix.image.pullPolicy | string | `"Always"` | API7 Gateway image pull policy |
 | apisix.image.repository | string | `"api7/api7-ee-3-gateway"` | API7 Gateway image repository |
-| apisix.image.tag | string | `"3.9.15"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
+| apisix.image.tag | string | `"3.9.16"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
 | apisix.kind | string | `"Deployment"` | Use a `DaemonSet` or `Deployment` |
 | apisix.lru | object | `{"secret":{"count":512,"neg_count":512,"neg_ttl":60,"ttl":300}}` | fine tune the parameters of LRU cache for some features like secret |
 | apisix.lru.secret.neg_ttl | int | `60` | in seconds |
 | apisix.lru.secret.ttl | int | `300` | in seconds |
+| apisix.matchURIEncodedSlash | bool | `false` | If true, keep URL-encoded slash (`%2F`) encoded when matching routes, so it is treated as part of a path parameter instead of a path separator. |
+| apisix.maxPostArgsReadableSize | int | `64` | Cap in MiB on the request body read when matching `post_arg.*` route predicates for JSON and multipart requests. Set to 0 to disable the limit. |
 | apisix.meta.luaSharedDict.prometheus-metrics | string | `"128m"` |  |
 | apisix.nodeSelector | object | `{}` | Node labels for API7 Gateway pod assignment |
 | apisix.normalizeURILikeServlet | bool | `false` | The URI normalization in servlet is a little different from the RFC's. See https://github.com/jakartaee/servlet/blob/master/spec/src/main/asciidoc/servlet-spec-body.adoc#352-uri-path-canonicalization, which is used under Tomcat. Turn this option on if you want to be compatible with servlet when matching URI path. |
@@ -130,6 +132,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | apisix.tolerations | list | `[]` | List of node taints to tolerate |
 | apisix.topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pod assignment https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/ The value is evaluated as a template |
 | apisix.tracing | bool | `false` | Enable comprehensive request lifecycle tracing (SSL/SNI, rewrite, access, header_filter, body_filter, and log). When disabled, OpenTelemetry collects only a single span per request. |
+| apisix.trustedAddresses | list | `[]` | IP/CIDR ranges whose `X-Forwarded-*` and `Forwarded` headers are trusted by API7 Gateway. |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -73,6 +73,12 @@ data:
       # which is used under Tomcat.
       # Turn this option on if you want to be compatible with servlet when matching URI path.
       normalize_uri_like_servlet: {{ .Values.apisix.normalizeURILikeServlet }}
+      match_uri_encoded_slash: {{ .Values.apisix.matchURIEncodedSlash }}
+      max_post_args_readable_size: {{ .Values.apisix.maxPostArgsReadableSize }}
+      {{- with .Values.apisix.trustedAddresses }}
+      trusted_addresses:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       router:
         http: {{ .Values.apisix.httpRouter }}  # radixtree_uri: match route by uri(base on radixtree)
                                     # radixtree_host_uri: match route by host + uri(base on radixtree)

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -112,6 +112,12 @@ apisix:
   # which is used under Tomcat.
   # Turn this option on if you want to be compatible with servlet when matching URI path.
   normalizeURILikeServlet: false
+  # -- If true, keep URL-encoded slash (`%2F`) encoded when matching routes, so it is treated as part of a path parameter instead of a path separator.
+  matchURIEncodedSlash: false
+  # -- Cap in MiB on the request body read when matching `post_arg.*` route predicates for JSON and multipart requests. Set to 0 to disable the limit.
+  maxPostArgsReadableSize: 64
+  # -- IP/CIDR ranges whose `X-Forwarded-*` and `Forwarded` headers are trusted by API7 Gateway.
+  trustedAddresses: []
   # -- Defines how apisix handles routing:
   # - radixtree_uri: match route by uri(base on radixtree)
   # - radixtree_host_uri: match route by host + uri(base on radixtree)
@@ -131,7 +137,7 @@ apisix:
     pullPolicy: Always
     # -- API7 Gateway image tag
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.9.15
+    tag: 3.9.16
 
   # -- Use a `DaemonSet` or `Deployment`
   kind: Deployment


### PR DESCRIPTION
Upgrade the API7 and Gateway charts for the 3.9.16 release.

This bumps chart app versions and image tags to 3.9.16, regenerates chart READMEs, and exposes the new gateway runtime settings for encoded slash matching, POST args readable size, and trusted forwarded-header addresses.