### PR TITLE
fix(gateway): decouple outbound CA trust store from tls.enabled; add README examples

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.9.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.9.6
+version: 3.9.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.9.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.9.7
+version: 3.9.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -55,6 +55,7 @@ Reference it (each entry mounts `filename` from `secretName` and appends it to t
 ```yaml
 gateway:
   tls:
+    enabled: true # default; additionalTrustedCAs only applies while the TLS listener is enabled
     additionalTrustedCAs:
       - secretName: keycloak-ca
         filename: keycloak-ca.crt
@@ -78,6 +79,7 @@ gateway:
   http:
     servicePort: 80
   tls:
+    enabled: true # required to expose the HTTPS port
     servicePort: 443
 ```
 

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -55,7 +55,6 @@ Reference it (each entry mounts `filename` from `secretName` and appends it to t
 ```yaml
 gateway:
   tls:
-    enabled: true # default; additionalTrustedCAs only applies while the TLS listener is enabled
     additionalTrustedCAs:
       - secretName: keycloak-ca
         filename: keycloak-ca.crt
@@ -79,7 +78,6 @@ gateway:
   http:
     servicePort: 80
   tls:
-    enabled: true # required to expose the HTTPS port
     servicePort: 443
 ```
 

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -30,6 +30,85 @@ helm delete [RELEASE_NAME] --namespace api7
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
+## Configuration examples
+
+The full list of values is in the [Parameters](#parameters) table below. The snippets here cover a
+few common setups — put them in a `values.yaml` and pass it with `-f values.yaml`, or translate each
+line into a `--set key=value` flag.
+
+### Trust additional CA certificates for outbound TLS
+
+The gateway verifies the TLS certificate of any external service it dials (for example an
+`openid-connect` identity provider) against its outbound trust store, which is the system CA bundle
+plus `gateway.tls.existingCASecret`. In a Control Plane-managed deployment `existingCASecret` already
+carries the Control Plane CA, so use `gateway.tls.additionalTrustedCAs` to trust an extra private or
+enterprise CA **on top of** it, without modifying that Secret.
+
+Create a Secret that holds the CA certificate:
+
+```sh
+kubectl -n api7 create secret generic keycloak-ca --from-file=keycloak-ca.crt=./keycloak-ca.crt
+```
+
+Reference it (each entry mounts `filename` from `secretName` and appends it to the trust store):
+
+```yaml
+gateway:
+  tls:
+    additionalTrustedCAs:
+      - secretName: keycloak-ca
+        filename: keycloak-ca.crt
+```
+
+The rendered `ssl_trusted_certificate` becomes `system,<existingCASecret CA>,<additional CA>`, so the
+system CAs and the existing CA are preserved. The trust store is merged when the gateway starts, so
+restart the gateway Pods after adding an entry or changing the Secret contents:
+
+```sh
+kubectl -n api7 rollout restart deploy/[RELEASE_NAME]
+```
+
+### Expose the gateway through a LoadBalancer
+
+`gateway.type` defaults to `NodePort`. To publish the proxy through a cloud load balancer instead:
+
+```yaml
+gateway:
+  type: LoadBalancer
+  http:
+    servicePort: 80
+  tls:
+    servicePort: 443
+```
+
+### Set replicas and resource limits
+
+```yaml
+apisix:
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+```
+
+### Inject extra environment variables
+
+```yaml
+apisix:
+  extraEnvVars:
+    - name: MY_ENV
+      value: "my-value"
+    - name: TOKEN_ENV
+      valueFrom:
+        secretKeyRef:
+          name: my-secret
+          key: token
+```
+
 ## Parameters
 
 ## Values

--- a/charts/gateway/README.md.gotmpl
+++ b/charts/gateway/README.md.gotmpl
@@ -31,6 +31,86 @@ helm delete [RELEASE_NAME] --namespace api7
 The command removes all the Kubernetes components associated with the chart and deletes the release.
 
 
+## Configuration examples
+
+The full list of values is in the [Parameters](#parameters) table below. The snippets here cover a
+few common setups — put them in a `values.yaml` and pass it with `-f values.yaml`, or translate each
+line into a `--set key=value` flag.
+
+### Trust additional CA certificates for outbound TLS
+
+The gateway verifies the TLS certificate of any external service it dials (for example an
+`openid-connect` identity provider) against its outbound trust store, which is the system CA bundle
+plus `gateway.tls.existingCASecret`. In a Control Plane-managed deployment `existingCASecret` already
+carries the Control Plane CA, so use `gateway.tls.additionalTrustedCAs` to trust an extra private or
+enterprise CA **on top of** it, without modifying that Secret.
+
+Create a Secret that holds the CA certificate:
+
+```sh
+kubectl -n api7 create secret generic keycloak-ca --from-file=keycloak-ca.crt=./keycloak-ca.crt
+```
+
+Reference it (each entry mounts `filename` from `secretName` and appends it to the trust store):
+
+```yaml
+gateway:
+  tls:
+    additionalTrustedCAs:
+      - secretName: keycloak-ca
+        filename: keycloak-ca.crt
+```
+
+The rendered `ssl_trusted_certificate` becomes `system,<existingCASecret CA>,<additional CA>`, so the
+system CAs and the existing CA are preserved. The trust store is merged when the gateway starts, so
+restart the gateway Pods after adding an entry or changing the Secret contents:
+
+```sh
+kubectl -n api7 rollout restart deploy/[RELEASE_NAME]
+```
+
+### Expose the gateway through a LoadBalancer
+
+`gateway.type` defaults to `NodePort`. To publish the proxy through a cloud load balancer instead:
+
+```yaml
+gateway:
+  type: LoadBalancer
+  http:
+    servicePort: 80
+  tls:
+    servicePort: 443
+```
+
+### Set replicas and resource limits
+
+```yaml
+apisix:
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 500m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+```
+
+### Inject extra environment variables
+
+```yaml
+apisix:
+  extraEnvVars:
+    - name: MY_ENV
+      value: "my-value"
+    - name: TOKEN_ENV
+      valueFrom:
+        secretKeyRef:
+          name: my-secret
+          key: token
+```
+
+
 ## Parameters
 
 {{ template "chart.valuesSection" . }}

--- a/charts/gateway/README.md.gotmpl
+++ b/charts/gateway/README.md.gotmpl
@@ -56,6 +56,7 @@ Reference it (each entry mounts `filename` from `secretName` and appends it to t
 ```yaml
 gateway:
   tls:
+    enabled: true # default; additionalTrustedCAs only applies while the TLS listener is enabled
     additionalTrustedCAs:
       - secretName: keycloak-ca
         filename: keycloak-ca.crt
@@ -79,6 +80,7 @@ gateway:
   http:
     servicePort: 80
   tls:
+    enabled: true # required to expose the HTTPS port
     servicePort: 443
 ```
 

--- a/charts/gateway/README.md.gotmpl
+++ b/charts/gateway/README.md.gotmpl
@@ -56,7 +56,6 @@ Reference it (each entry mounts `filename` from `secretName` and appends it to t
 ```yaml
 gateway:
   tls:
-    enabled: true # default; additionalTrustedCAs only applies while the TLS listener is enabled
     additionalTrustedCAs:
       - secretName: keycloak-ca
         filename: keycloak-ca.crt
@@ -80,7 +79,6 @@ gateway:
   http:
     servicePort: 80
   tls:
-    enabled: true # required to expose the HTTPS port
     servicePort: 443
 ```
 

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -199,14 +199,15 @@ Output: JSON {"entries": [{"port": 9200, "nodePort": ""}, ...]}
 
 {{/*
 Build the value of `apisix.ssl.ssl_trusted_certificate` — the gateway's outbound
-trust store. Starts from the system CA bundle (`system`), then appends the
-Control Plane CA (gateway.tls.existingCASecret) and every entry in
-gateway.tls.additionalTrustedCAs, matching the mount paths rendered in _pod.tpl.
-Returns an empty string when TLS is disabled or no CA is configured, so the
-caller can omit the key entirely.
+trust store, used to verify external services the gateway dials (etcd/Control
+Plane, openid-connect, loggers, ...). It is independent of the inbound HTTPS
+listener (gateway.tls.enabled). Starts from the system CA bundle (`system`),
+then appends the Control Plane CA (gateway.tls.existingCASecret) and every entry
+in gateway.tls.additionalTrustedCAs, matching the mount paths rendered in
+_pod.tpl. Returns an empty string when no CA is configured, so the caller can
+omit the key entirely.
 */}}
 {{- define "gateway.sslTrustedCertificate" -}}
-{{- if .Values.gateway.tls.enabled -}}
 {{- $paths := list -}}
 {{- if .Values.gateway.tls.existingCASecret -}}
 {{- $paths = append $paths (printf "/usr/local/apisix/conf/ssl/%s" .Values.gateway.tls.certCAFilename) -}}
@@ -216,6 +217,5 @@ caller can omit the key entirely.
 {{- end -}}
 {{- if $paths -}}
 {{- printf "system,%s" (join "," $paths) -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/gateway/templates/_pod.tpl
+++ b/charts/gateway/templates/_pod.tpl
@@ -184,17 +184,15 @@ spec:
         - mountPath: /usr/local/apisix/conf/config.yaml
           name: apisix-config
           subPath: config.yaml
-      {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.existingCASecret }}
+      {{- if .Values.gateway.tls.existingCASecret }}
         - mountPath: /usr/local/apisix/conf/ssl/{{ .Values.gateway.tls.certCAFilename }}
           name: ssl
           subPath: {{ .Values.gateway.tls.certCAFilename }}
       {{- end }}
-      {{- if .Values.gateway.tls.enabled }}
       {{- range $i, $ca := .Values.gateway.tls.additionalTrustedCAs }}
         - mountPath: /usr/local/apisix/conf/ssl/additional-ca-{{ $i }}
           name: additional-ca-{{ $i }}
           readOnly: true
-      {{- end }}
       {{- end }}
 
       {{- if .Values.etcd.auth.tls.enabled }}
@@ -298,12 +296,11 @@ spec:
     - configMap:
         name: {{ include "apisix.fullname" . }}
       name: apisix-config
-    {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.existingCASecret }}
+    {{- if .Values.gateway.tls.existingCASecret }}
     - secret:
         secretName: {{ .Values.gateway.tls.existingCASecret | quote }}
       name: ssl
     {{- end }}
-    {{- if .Values.gateway.tls.enabled }}
     {{- range $i, $ca := .Values.gateway.tls.additionalTrustedCAs }}
     - secret:
         secretName: {{ $ca.secretName | quote }}
@@ -311,7 +308,6 @@ spec:
           - key: {{ $ca.filename | quote }}
             path: {{ $ca.filename | quote }}
       name: additional-ca-{{ $i }}
-    {{- end }}
     {{- end }}
     {{- if .Values.etcd.auth.tls.enabled }}
     - secret:


### PR DESCRIPTION
### Fix: outbound CA trust store was gated on the inbound TLS listener

`apisix.ssl.ssl_trusted_certificate` is the gateway's **outbound** trust store — it verifies the TLS certificates of services the gateway *dials* (etcd/Control Plane, `openid-connect` IdPs, loggers, ...). It has nothing to do with the inbound HTTPS listener (`gateway.tls.enabled`).

But `gateway.tls.existingCASecret` and `gateway.tls.additionalTrustedCAs` (added in #318) were both gated on `gateway.tls.enabled`. So with the HTTPS listener disabled, the trust store and its Secret mounts silently disappeared — even though `etcd.auth.tls.verify: true` or an `openid-connect` `ssl_verify: true` still needs them.

This gates the `ssl_trusted_certificate` rendering and the CA Secret mounts on whether a CA is actually configured, not on `gateway.tls.enabled`:

- **No change** for the default (`gateway.tls.enabled: true`).
- Only fixes the `gateway.tls.enabled: false` case.

### Docs: configuration examples

Also adds a **Configuration examples** section to `README.md.gotmpl` (regenerated into `README.md`). Covers `additionalTrustedCAs`, exposing via LoadBalancer, replicas/resources, and extra env vars.

Chart version bumped `3.9.6` → `3.9.7` (functional fix). 3.9 line of #319.
