### PR TITLE
release(aisix-cp): 0.4.0

### DIFF
--- a/charts/aisix-cp/Chart.yaml
+++ b/charts/aisix-cp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix-cp
 description: Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 type: application
-version: 0.3.1
-appVersion: "0.3.1"
+version: 0.4.0
+appVersion: "0.4.0"
 
 maintainers:
   - name: API7

--- a/charts/aisix-cp/README.md
+++ b/charts/aisix-cp/README.md
@@ -1,6 +1,6 @@
 # aisix-cp
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.1](https://img.shields.io/badge/AppVersion-0.3.1-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 


### PR DESCRIPTION
Release the public `aisix-cp` chart at `0.4.0`.

- Bump `version` and `appVersion` to `0.4.0`; regenerate `README.md`.
- Version-only release sync: the source-of-truth chart (`control-plane/helm/aisix-cp`) had no functional changes since `0.3.1`, so no template/values deltas are ported this cycle.
- Preserves the public adaptations: `docker.io` registries, `tag: ""` → `.Chart.AppVersion`, always-emit `api.dpImage` default → `docker.io/api7/aisix:<appVersion>`, and `README.md`.

`helm lint` clean; `helm template` renders `aisix-cp-{api,dpm,ui}:0.4.0` and `AISIX_CLOUD_DP_IMAGE=docker.io/api7/aisix:0.4.0`, with the dpm `/healthz` probes intact.

Merging publishes `aisix-cp-0.4.0` to https://charts.api7.ai. The pinned images (`docker.io/api7/aisix:0.4.0` and `docker.io/api7/aisix-cp-{api,dpm,ui}:0.4.0`) are already published.
