### PR TITLE
release(aisix-cp): 0.5.0

### DIFF
--- a/charts/aisix-cp/Chart.yaml
+++ b/charts/aisix-cp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix-cp
 description: Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 type: application
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.5.0
+appVersion: "0.5.0"
 
 maintainers:
   - name: API7

--- a/charts/aisix-cp/README.md
+++ b/charts/aisix-cp/README.md
@@ -1,6 +1,6 @@
 # aisix-cp
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
 
 Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 
@@ -28,6 +28,7 @@ Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 | api.image.repository | string | `"docker.io/api7/aisix-cp-api"` |  |
 | api.image.tag | string | `""` |  |
 | api.nodeSelector | object | `{}` |  |
+| api.notifyAllowPrivateURLs | bool | `false` |  |
 | api.oauthEnabled | bool | `false` |  |
 | api.playgroundAllowPrivateIPs | bool | `false` |  |
 | api.podSecurityContext.fsGroup | int | `101` |  |

--- a/charts/aisix-cp/templates/api-deployment.yaml
+++ b/charts/aisix-cp/templates/api-deployment.yaml
@@ -81,6 +81,10 @@ spec:
             - name: AISIX_PLAYGROUND_ALLOW_PRIVATE_IPS
               value: "1"
             {{- end }}
+            {{- if .Values.api.notifyAllowPrivateURLs }}
+            - name: AISIX_CLOUD_NOTIFY_ALLOW_PRIVATE_URLS
+              value: "true"
+            {{- end }}
             - name: AISIX_CLOUD_DP_IMAGE
               value: {{ .Values.api.dpImage | default (printf "docker.io/api7/aisix:%s" .Chart.AppVersion) | quote }}
             {{- with .Values.api.extraEnvVars }}

--- a/charts/aisix-cp/templates/ui-deployment.yaml
+++ b/charts/aisix-cp/templates/ui-deployment.yaml
@@ -70,6 +70,17 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          volumeMounts:
+            # Next.js standalone writes its image/fetch cache under
+            # .next/cache. With readOnlyRootFilesystem and no writable
+            # mount here, every cache write fails and a failed write can
+            # permanently wedge the /_next/image in-flight dedup entry
+            # for a variant (requests then hang until the LB times out).
+            - name: next-cache
+              mountPath: /app/.next/cache
+      volumes:
+        - name: next-cache
+          emptyDir: {}
       {{- with .Values.ui.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/aisix-cp/values.yaml
+++ b/charts/aisix-cp/values.yaml
@@ -46,6 +46,11 @@ api:
   ## enable this only for self-hosted deployments whose models live on an
   ## internal network the cp-api pod can route to.
   playgroundAllowPrivateIPs: false
+  ## Allow notification channels (budget alert webhooks / Slack) to point
+  ## at private / internal addresses. Blocked by default (SSRF guard);
+  ## enable only for self-hosted deployments whose webhook receivers live
+  ## on an intranet the cp-api pod can route to.
+  notifyAllowPrivateURLs: false
 
 ## @section dp-manager
 dpm:


### PR DESCRIPTION
Releases `aisix-cp` 0.5.0. Bumps `version` and `appVersion` to `0.5.0`, syncs the control-plane chart deltas accumulated since 0.4.0, and regenerates `README.md`.

## Synced from the control-plane chart

- **`api.notifyAllowPrivateURLs`** (default `false`) gates a new `AISIX_CLOUD_NOTIFY_ALLOW_PRIVATE_URLS` env var on the cp-api container. Budget alert notification channels (webhook / Slack) block private and internal addresses by default as an SSRF guard; private deployments whose webhook receiver lives on an intranet the cp-api pod can route to need this switch.
- **UI `.next/cache` volume** — the dashboard container mounts an `emptyDir` at `/app/.next/cache`. Next.js standalone writes its image and fetch cache there; under `readOnlyRootFilesystem` every write fails, and a failed write can permanently wedge the in-flight dedup entry for an image variant, so those requests hang until the load balancer times out.

## Preserved public adaptations

Unchanged and still divergent from the control-plane chart by design: `docker.io` registries, empty image tags resolving to `.Chart.AppVersion`, the always-emitted `api.dpImage` default (`docker.io/api7/aisix:<appVersion>`), and this chart's `README.md`.

## Verification

`helm lint` passes. Rendered templates resolve every image to `docker.io/...:0.5.0` and `AISIX_CLOUD_DP_IMAGE` to `docker.io/api7/aisix:0.5.0`; all four images are published. The new env var renders only when the value is enabled, and the UI volume and mount render as expected.

Merging publishes `aisix-cp-0.5.0` to charts.api7.ai.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to allow notification webhooks to target private or internal URLs, disabled by default.
  - Added writable runtime caching for the web interface to improve reliability in read-only container environments.

- **Documentation**
  - Updated chart version information and documented the new notification URL setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->