### PR TITLE
release(aisix-cp): 0.5.1

### DIFF
--- a/charts/aisix-cp/Chart.yaml
+++ b/charts/aisix-cp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: aisix-cp
 description: Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "0.5.0"
 
 maintainers:

--- a/charts/aisix-cp/README.md
+++ b/charts/aisix-cp/README.md
@@ -1,6 +1,6 @@
 # aisix-cp
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
 
 Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 

--- a/charts/aisix-cp/templates/api-deployment.yaml
+++ b/charts/aisix-cp/templates/api-deployment.yaml
@@ -90,6 +90,18 @@ spec:
             {{- with .Values.api.extraEnvVars }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          # cp-api runs the schema migration (db.OpenAndMigrate) before
+          # it binds :8080, so /healthz does not answer for the whole
+          # migration. On an upgrade against a populated database that
+          # can outlast the liveness budget below and kill the pod
+          # MID-MIGRATION. The startupProbe suspends liveness and
+          # readiness until the server is actually up.
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 5
+            failureThreshold: 60
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/aisix-cp/templates/dpm-deployment.yaml
+++ b/charts/aisix-cp/templates/dpm-deployment.yaml
@@ -70,7 +70,24 @@ spec:
           # Service) and liveness (pod restarted). When the health
           # listener is disabled (healthListen=""), the dp-manager serves
           # no /healthz, so fall back to a TCP check on the mTLS port.
+          #
+          # On a cold start the dp-manager binds NEITHER port until
+          # bootstrapCertManagerWithRetry succeeds: cp-api owns the
+          # schema migration, so on a first boot dp-manager sits in an
+          # in-process retry loop (~2 min budget) waiting for the shared
+          # tables to appear. The liveness settings below would kill it
+          # ~30s in — well inside its own retry window — turning a
+          # benign, self-healing boot race into a crash loop. The
+          # startupProbe suspends liveness and readiness until the first
+          # success, with a budget that must stay LONGER than that
+          # in-process retry window (see ci-helm.yml, which asserts it).
           {{- if .Values.dpm.service.healthListen }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            periodSeconds: 5
+            failureThreshold: 36
           readinessProbe:
             httpGet:
               path: /healthz
@@ -85,6 +102,11 @@ spec:
             periodSeconds: 10
             failureThreshold: 3
           {{- else }}
+          startupProbe:
+            tcpSocket:
+              port: tls
+            periodSeconds: 5
+            failureThreshold: 36
           readinessProbe:
             tcpSocket:
               port: tls


### PR DESCRIPTION
Chart-only patch on top of the 0.5.0 app release. `appVersion` stays `0.5.0` — no application change, so every image still resolves to `docker.io/...:0.5.0`.

## Problem

The chart kills both CP pods while they are still legitimately starting up.

**dp-manager** binds neither of its ports until it has obtained the shared schema, which cp-api creates. On a first boot it retries in-process for ~95s waiting for that — a race it is built to absorb. The liveness probe (`initialDelaySeconds: 10`, `periodSeconds: 10`, `failureThreshold: 3`) killed it about 40s in, well inside that window, so the pod never reached the end of its own retry budget.

**cp-api** has the same shape: it runs its schema migration before binding `:8080`, so `/healthz` stays unanswered for the whole migration. An empty database migrates fast, but an upgrade against a populated one can outlast the liveness budget and be killed **mid-migration**.

## Change

A `startupProbe` on both deployments. While a startup probe is in effect the kubelet suspends liveness and readiness, so the existing probes are unchanged and take over once the process is actually serving. Budgets are sized to outlast the work they cover — 180s for dp-manager, 300s for cp-api's migration.

## Verification

Both charts installed on kind with `api.replicaCount=0`, so dp-manager can never obtain its schema:

| chart | result |
|---|---|
| `aisix-cp` 0.5.0 (published) | `CrashLoopBackOff`, 6 restarts, with the event `Container dpm failed liveness probe, will be restarted` |
| this branch (0.5.1) | running, 0 restarts, no liveness-probe failures |

`helm lint` passes, and the rendered manifests still resolve every image to `docker.io/...:0.5.0`.

Synced from the source-of-truth chart in AISIX-Cloud#1135; the residual diff against it is only the usual public adaptations (registries, empty tags resolving to `.Chart.AppVersion`, the `api.dpImage` default, and `README.md`).