### PR TITLE
chore: upgrade api7 and gateway to v3.10.4

### DIFF
--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.10.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.10.2
+version: 3.10.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.10.3"
+appVersion: "3.10.4"
 
 maintainers:
   - name: API7

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -1,6 +1,6 @@
 # api7ee3
 
-![Version: 3.10.2](https://img.shields.io/badge/Version-3.10.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.10.3](https://img.shields.io/badge/AppVersion-3.10.3-informational?style=flat-square)
+![Version: 3.10.3](https://img.shields.io/badge/Version-3.10.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.10.4](https://img.shields.io/badge/AppVersion-3.10.4-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -29,7 +29,7 @@ A Helm chart for Kubernetes
 | dashboard.extraVolumes | list | `[]` |  |
 | dashboard.image.pullPolicy | string | `"Always"` |  |
 | dashboard.image.repository | string | `"api7/api7-ee-3-integrated"` |  |
-| dashboard.image.tag | string | `"v3.10.3"` |  |
+| dashboard.image.tag | string | `"v3.10.4"` |  |
 | dashboard.keyCertSecret | string | `""` |  |
 | dashboard.livenessProbe.failureThreshold | int | `30` |  |
 | dashboard.livenessProbe.initialDelaySeconds | int | `180` |  |
@@ -42,6 +42,8 @@ A Helm chart for Kubernetes
 | dashboard.topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pod assignment https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/ The value is evaluated as a template |
 | dashboard_configuration.audit.retention_days | int | `60` |  |
 | dashboard_configuration.console.addr | string | `"http://127.0.0.1:3000"` |  |
+| dashboard_configuration.console.hybrid_mode | bool | `false` | hybrid_mode hides the license and core-quota UI, for deployments where the license is operated for the user rather than by them. |
+| dashboard_configuration.console.sentry | object | `{"dsn":"","enabled":false,"release":""}` | sentry configures the console's browser error reporting. |
 | dashboard_configuration.consumer_proxy.cache_failure_count | int | `512` |  |
 | dashboard_configuration.consumer_proxy.cache_failure_ttl | int | `60` |  |
 | dashboard_configuration.consumer_proxy.cache_success_count | int | `512` |  |
@@ -49,6 +51,7 @@ A Helm chart for Kubernetes
 | dashboard_configuration.consumer_proxy.enable | bool | `false` |  |
 | dashboard_configuration.database.dsn | string | `"postgres://api7ee:changeme@api7-postgresql:5432/api7ee"` |  |
 | dashboard_configuration.database.max_idle_time | string | `"30s"` |  |
+| dashboard_configuration.database.max_lifetime | string | `"1h"` | Maximum lifetime of a pooled connection. Bounded by default so that connections pinned to a primary demoted by a failover are eventually retired; do not set it to 0 |
 | dashboard_configuration.database.max_open_conns | int | `30` |  |
 | dashboard_configuration.database.timeout | string | `"5s"` |  |
 | dashboard_configuration.developer_proxy.cache_failure_count | int | `256` |  |
@@ -120,7 +123,7 @@ A Helm chart for Kubernetes
 | developer_portal.extraVolumes | list | `[]` |  |
 | developer_portal.image.pullPolicy | string | `"Always"` |  |
 | developer_portal.image.repository | string | `"api7/api7-ee-developer-portal"` |  |
-| developer_portal.image.tag | string | `"v3.10.3"` |  |
+| developer_portal.image.tag | string | `"v3.10.4"` |  |
 | developer_portal.keyCertSecret | string | `""` |  |
 | developer_portal.livenessProbe.failureThreshold | int | `10` |  |
 | developer_portal.livenessProbe.initialDelaySeconds | int | `60` |  |
@@ -133,6 +136,7 @@ A Helm chart for Kubernetes
 | developer_portal.topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pod assignment https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/ The value is evaluated as a template |
 | developer_portal_configuration.database.dsn | string | `"postgres://api7ee:changeme@api7-postgresql:5432/api7ee"` |  |
 | developer_portal_configuration.database.max_idle_time | string | `"30s"` |  |
+| developer_portal_configuration.database.max_lifetime | string | `"1h"` | Maximum lifetime of a pooled connection. Bounded by default so that connections pinned to a primary demoted by a failover are eventually retired; do not set it to 0 |
 | developer_portal_configuration.database.max_open_conns | int | `30` |  |
 | developer_portal_configuration.database.timeout | string | `"5s"` |  |
 | developer_portal_configuration.enable | bool | `true` |  |
@@ -166,7 +170,7 @@ A Helm chart for Kubernetes
 | dp_manager.extraVolumes | list | `[]` |  |
 | dp_manager.image.pullPolicy | string | `"Always"` |  |
 | dp_manager.image.repository | string | `"api7/api7-ee-dp-manager"` |  |
-| dp_manager.image.tag | string | `"v3.10.3"` |  |
+| dp_manager.image.tag | string | `"v3.10.4"` |  |
 | dp_manager.livenessProbe.failureThreshold | int | `10` |  |
 | dp_manager.livenessProbe.initialDelaySeconds | int | `60` |  |
 | dp_manager.livenessProbe.periodSeconds | int | `3` |  |
@@ -181,6 +185,7 @@ A Helm chart for Kubernetes
 | dp_manager_configuration.consumer_cache.size | int | `50000` |  |
 | dp_manager_configuration.database.dsn | string | `"postgres://api7ee:changeme@api7-postgresql:5432/api7ee"` |  |
 | dp_manager_configuration.database.max_idle_time | string | `"30s"` |  |
+| dp_manager_configuration.database.max_lifetime | string | `"1h"` | Maximum lifetime of a pooled connection. Bounded by default so that connections pinned to a primary demoted by a failover are eventually retired; do not set it to 0 |
 | dp_manager_configuration.database.max_open_conns | int | `30` |  |
 | dp_manager_configuration.database.timeout | string | `"5s"` |  |
 | dp_manager_configuration.developer_cache.evict_interval | string | `"5s"` |  |
@@ -232,7 +237,7 @@ A Helm chart for Kubernetes
 | file_server.enabled | bool | `false` |  |
 | file_server.image.pullPolicy | string | `"Always"` |  |
 | file_server.image.repository | string | `"api7/api7-ee-file-server"` |  |
-| file_server.image.tag | string | `"v3.10.3"` |  |
+| file_server.image.tag | string | `"v3.10.4"` |  |
 | file_server.livenessProbe.failureThreshold | int | `10` |  |
 | file_server.livenessProbe.initialDelaySeconds | int | `60` |  |
 | file_server.livenessProbe.periodSeconds | int | `3` |  |

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -18,7 +18,7 @@ dashboard:
     repository: api7/api7-ee-3-integrated
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.10.3"
+    tag: "v3.10.4"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -55,7 +55,7 @@ dp_manager:
     repository: api7/api7-ee-dp-manager
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.10.3"
+    tag: "v3.10.4"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -92,7 +92,7 @@ file_server:
   image:
     repository: api7/api7-ee-file-server
     pullPolicy: Always
-    tag: "v3.10.3"
+    tag: "v3.10.4"
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 3
@@ -110,7 +110,7 @@ developer_portal:
     repository: api7/api7-ee-developer-portal
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.10.3"
+    tag: "v3.10.4"
 
   extraEnvVars: []
   extraVolumes: []
@@ -362,7 +362,9 @@ dashboard_configuration:
     dsn: "postgres://api7ee:changeme@api7-postgresql:5432/api7ee"
     max_open_conns: 30
     max_idle_time: 30s
-    # max_lifetime: 60s
+    # -- Maximum lifetime of a pooled connection. Bounded by default so that connections
+    # pinned to a primary demoted by a failover are eventually retired; do not set it to 0
+    max_lifetime: 1h
     timeout: 5s
     # vault:
     #   enabled: false
@@ -406,6 +408,22 @@ dashboard_configuration:
       - "/api/v1/labels"
   console:
     addr: "http://127.0.0.1:3000"
+    # -- hybrid_mode hides the license and core-quota UI, for deployments where
+    # the license is operated for the user rather than by them.
+    hybrid_mode: false
+    # -- sentry configures the console's browser error reporting.
+    sentry:
+      enabled: false
+      dsn: ""
+      release: ""
+    # -- custom_menu_group adds an extra group of external links to the gateway
+    # sidebar. Every item needs a non-empty name and an absolute http/https
+    # url; the whole group is dropped when it does not validate.
+    # custom_menu_group:
+    #   title: "Resources"
+    #   items:
+    #     - name: "API7 Docs"
+    #       url: "https://docs.api7.ai"
   audit:
     retention_days: 60
   consumer_proxy:
@@ -490,7 +508,9 @@ dp_manager_configuration:
     dsn: "postgres://api7ee:changeme@api7-postgresql:5432/api7ee"
     max_open_conns: 30
     max_idle_time: 30s
-    # max_lifetime: 60s
+    # -- Maximum lifetime of a pooled connection. Bounded by default so that connections
+    # pinned to a primary demoted by a failover are eventually retired; do not set it to 0
+    max_lifetime: 1h
     timeout: 5s
     # vault:
     #   enabled: false
@@ -569,7 +589,9 @@ developer_portal_configuration:
     dsn: "postgres://api7ee:changeme@api7-postgresql:5432/api7ee"
     max_open_conns: 30
     max_idle_time: 30s
-    # max_lifetime: 60s
+    # -- Maximum lifetime of a pooled connection. Bounded by default so that connections
+    # pinned to a primary demoted by a failover are eventually retired; do not set it to 0
+    max_lifetime: 1h
     timeout: 5s
     # vault:
     #   enabled: false

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -16,12 +16,12 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.10.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.10.9
+version: 3.10.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "3.10.3"
+appVersion: "3.10.4"
 
 maintainers:
   - name: API7

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -158,7 +158,7 @@ apisix:
 | apisix.httpRouter | string | `"radixtree_host_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
 | apisix.image.pullPolicy | string | `"Always"` | API7 Gateway image pull policy |
 | apisix.image.repository | string | `"api7/api7-ee-3-gateway"` | API7 Gateway image repository |
-| apisix.image.tag | string | `"3.10.3"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
+| apisix.image.tag | string | `"3.10.4"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
 | apisix.kind | string | `"Deployment"` | Use a `DaemonSet` or `Deployment` |
 | apisix.lru | object | `{"secret":{"count":512,"neg_count":512,"neg_ttl":60,"ttl":300}}` | fine tune the parameters of LRU cache for some features like secret |
 | apisix.lru.secret.count | int | `512` | Maximum number of cached secret values |
@@ -328,6 +328,8 @@ apisix:
 | nginx.http.variablesHashMaxSize | int | `2048` | The maximum size of the nginx variables hash table |
 | nginx.maxPendingTimers | int | `16384` | Maximum number of pending timers. Increase it if you see "too many pending timers" error |
 | nginx.maxRunningTimers | int | `4096` | Maximum number of running timers. Increase it if you see "lua_max_running_timers are not enough" error |
+| nginx.stream | object | `{"realIpFrom":[]}` | Nginx stream subsystem configurations |
+| nginx.stream.realIpFrom | list | `[]` | Trusted addresses known to send a correct PROXY protocol header on stream (TCP/UDP) ports. On a connection from a trusted address that carries an inbound PROXY protocol header, the client address is replaced by the one in the header. Only takes effect on ports that accept the PROXY protocol (`apisix.stream.tcp[].proxyProtocol`). Empty by default, so the client address is always the directly connected peer, see [set_real_ip_from](https://nginx.org/en/docs/stream/ngx_stream_realip_module.html#set_real_ip_from) |
 | nginx.workerConnections | string | `"10620"` | The maximum number of connections that each worker process can open |
 | nginx.workerProcesses | string | `"auto"` | The number of nginx worker processes. `auto` means the number of CPU cores |
 | nginx.workerRlimitNofile | string | `"20480"` | The number of files a worker process can open, should be larger than nginx.workerConnections |

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -212,6 +212,12 @@ data:
           {{- .Values.logs.stream.accessLogFormat | nindent 10 }}
         access_log_format_escape: {{ .Values.logs.stream.accessLogFormatEscape }}
         {{- end }}
+        {{- if .Values.nginx.stream.realIpFrom }}
+        real_ip_from:                  # https://nginx.org/en/docs/stream/ngx_stream_realip_module.html#set_real_ip_from
+          {{- range $ip := .Values.nginx.stream.realIpFrom }}
+          - {{ $ip | quote }}
+          {{- end }}
+        {{- end }}
       http:
         {{- if and (.Values.deployment.fallback_cp) (eq .Values.deployment.fallback_cp.mode "write") }}
         enable_access_log: false

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -205,7 +205,7 @@ apisix:
     pullPolicy: Always
     # -- API7 Gateway image tag
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.10.3
+    tag: 3.10.4
 
   # -- Use a `DaemonSet` or `Deployment`
   kind: Deployment
@@ -561,6 +561,16 @@ nginx:
   maxRunningTimers: 4096
   # -- List of environment variable names allowed to be accessed within nginx (rendered as nginx `env` directives)
   envs: []
+  # -- Nginx stream subsystem configurations
+  stream:
+    # -- Trusted addresses known to send a correct PROXY protocol header on stream (TCP/UDP) ports.
+    # On a connection from a trusted address that carries an inbound PROXY protocol header, the client
+    # address is replaced by the one in the header. Only takes effect on ports that accept the PROXY
+    # protocol (`apisix.stream.tcp[].proxyProtocol`). Empty by default, so the client address is always
+    # the directly connected peer,
+    # see [set_real_ip_from](https://nginx.org/en/docs/stream/ngx_stream_realip_module.html#set_real_ip_from)
+    realIpFrom: []
+    # - 192.168.1.0/24
   # -- Nginx HTTP subsystem configurations
   http:
     # -- timeout during which a keep-alive client connection will stay open on the server side


### PR DESCRIPTION
Chart release for API7 EE 3.10.4. 3.10 is the latest line, so this targets `main`.

## Version bumps

| Chart | Chart version | appVersion |
| --- | --- | --- |
| `charts/api7` | 3.10.2 → 3.10.3 | 3.10.3 → **3.10.4** |
| `charts/gateway` | 3.10.9 → 3.10.10 | 3.10.3 → **3.10.4** |

Image tags move to `v3.10.4` for dashboard, dp_manager, file_server and developer_portal, and to `3.10.4` for the gateway.

## Structural changes

**`charts/gateway` — new `nginx.stream.realIpFrom`.** The gateway gained stream `set_real_ip_from` support in 3.10.4 (`nginx_config.stream.real_ip_from`, backed by `--with-stream_realip_module` in apisix-runtime 1.3.11), so a gateway sitting behind a load balancer that speaks the PROXY protocol on stream ports can resolve the real client address instead of the directly connected peer. The chart renders `nginx_config` explicitly, so this needed a values field plus template rendering rather than passthrough. The block is emitted only when the list is non-empty, which matches the gateway's own default of trusting no address.

**`charts/api7` — `console.*`.** 3.10.4 serves `/api/fe-config` from the Go binary, driven by `console.*` config keys. The existing `dashboard_configuration.console` block (which already carried `addr`) is extended with `hybrid_mode`, `sentry` and a commented `custom_menu_group`, mirroring `control-plane` `helm/values.yaml` verbatim.

**`charts/api7` — `database.max_lifetime`.** The control plane now bounds pooled connection lifetime by default, so that connections pinned to a primary that a failover has demoted to read-only are eventually retired. The commented `# max_lifetime: 60s` example is replaced with an explicit `max_lifetime: 1h` for dashboard, dp_manager and developer_portal, matching the control plane's own chart and its new default.

Config keys that are **not** chart-exposed: the remaining gateway `config-default.yaml` delta for this release is comment-only, and the control plane's other changes land in maps the chart already forwards with `toYaml`.

## Validation

* `helm lint charts/api7 charts/gateway` — 0 failed.
* `helm template` on both charts renders the expected images (`api7-ee-3-integrated:v3.10.4`, `api7-ee-dp-manager:v3.10.4`, `api7-ee-developer-portal:v3.10.4`, `api7-ee-3-gateway:3.10.4`).
* Stream real IP verified both ways: absent from the rendered `stream:` block by default, and present as a quoted list under `--set nginx.stream.realIpFrom[0]=192.168.1.0/24`.
* `dashboard_configuration.console` confirmed to be a single key after the merge — the new keys extend the existing block instead of shadowing `console.addr`.
* READMEs regenerated with `make helm-docs`.
