### PR TITLE
release(aisix-cp): 0.6.0

### DIFF
--- a/charts/aisix-cp/Chart.yaml
+++ b/charts/aisix-cp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix-cp
 description: Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 type: application
-version: 0.5.1
-appVersion: "0.5.0"
+version: 0.6.0
+appVersion: "0.6.0"
 
 maintainers:
   - name: API7

--- a/charts/aisix-cp/README.md
+++ b/charts/aisix-cp/README.md
@@ -1,6 +1,6 @@
 # aisix-cp
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
 
 Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 


### PR DESCRIPTION
Releases `aisix-cp` 0.6.0.

## Changes

- `Chart.yaml`: `version` and `appVersion` → `0.6.0`
- `README.md`: regenerated by helm-docs (version badges)

No template or values changes. The accumulated delta from the development chart — the cp-api and dp-manager startup probes — already shipped in the 0.5.1 chart-only patch, so this cycle has no functional chart change left to sync. The residual diff against the source-of-truth chart (`control-plane/helm/aisix-cp`) is only the intentional public adaptations: `docker.io` registries, empty image tags resolving to `.Chart.AppVersion`, the `api.dpImage` default, and this README.

## Images

`appVersion` pins the image tags, and all four are published:

- `docker.io/api7/aisix-cp-api:0.6.0`
- `docker.io/api7/aisix-cp-dpm:0.6.0`
- `docker.io/api7/aisix-cp-ui:0.6.0`
- `docker.io/api7/aisix:0.6.0` (the `api.dpImage` default)

Merging publishes `aisix-cp-0.6.0` to https://charts.api7.ai and rolls the POC environment onto 0.6.0.