### PR TITLE
chore: allow L4 upstream schemes (tcp/tls/udp) in ingress-controller CRDs

### DIFF
--- a/charts/ingress-controller/Chart.yaml
+++ b/charts/ingress-controller/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - api7
   - crd
 type: application
-version: 0.1.24
+version: 0.1.25
 appVersion: 2.1.0
 maintainers:
   - name: API7

--- a/charts/ingress-controller/README.md
+++ b/charts/ingress-controller/README.md
@@ -1,6 +1,6 @@
 # api7-ingress-controller
 
-![Version: 0.1.24](https://img.shields.io/badge/Version-0.1.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 0.1.25](https://img.shields.io/badge/Version-0.1.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
 
 Ingress Controller for API7
 

--- a/charts/ingress-controller/crds/apisix-crds.yaml
+++ b/charts/ingress-controller/crds/apisix-crds.yaml
@@ -2033,12 +2033,18 @@ spec:
                       description: |-
                         Scheme is the protocol used to communicate with the upstream.
                         Default is `http`.
-                        Can be `http`, `https`, `grpc`, or `grpcs`.
+                        For L7 proxy, it can be `http`, `https`, `grpc`, or `grpcs`.
+                        For L4 proxy, it can be `tcp`, `tls`, or `udp`.
+                        The L4 values apply to stream routes only; using them for an HTTP route
+                        makes the upstream unreachable.
                       enum:
                       - http
                       - https
                       - grpc
                       - grpcs
+                      - tcp
+                      - tls
+                      - udp
                       type: string
                     subsets:
                       description: |-
@@ -2112,12 +2118,18 @@ spec:
                 description: |-
                   Scheme is the protocol used to communicate with the upstream.
                   Default is `http`.
-                  Can be `http`, `https`, `grpc`, or `grpcs`.
+                  For L7 proxy, it can be `http`, `https`, `grpc`, or `grpcs`.
+                  For L4 proxy, it can be `tcp`, `tls`, or `udp`.
+                  The L4 values apply to stream routes only; using them for an HTTP route
+                  makes the upstream unreachable.
                 enum:
                 - http
                 - https
                 - grpc
                 - grpcs
+                - tcp
+                - tls
+                - udp
                 type: string
               subsets:
                 description: |-
@@ -2529,12 +2541,18 @@ spec:
                 description: |-
                   Scheme is the protocol used to communicate with the upstream.
                   Default is `http`.
-                  Can be `http`, `https`, `grpc`, or `grpcs`.
+                  For L7 proxy, it can be `http`, `https`, `grpc`, or `grpcs`.
+                  For L4 proxy, it can be `tcp`, `tls`, or `udp`.
+                  The L4 values apply to stream routes only; using them for an HTTP route
+                  makes the upstream unreachable.
                 enum:
                 - http
                 - https
                 - grpc
                 - grpcs
+                - tcp
+                - tls
+                - udp
                 type: string
               targetRefs:
                 description: |-


### PR DESCRIPTION
## Description

The gateway accepts `tcp`, `tls` and `udp` as upstream schemes for L4 proxying, and `scheme: tls` is what makes the gateway establish the TLS session with a stream upstream (plain TCP in from the client, TLS out to the backend). The CRDs bundled in this chart still restrict `ApisixUpstream.spec.scheme` and `BackendTrafficPolicy.spec.scheme` to the L7 set, so on a standard Helm installation the API server rejects `tcp`/`tls`/`udp` before the controller ever sees the resource.

This updates the three `scheme` fields in `charts/ingress-controller/crds/apisix-crds.yaml` (top-level and `portLevelSettings` of ApisixUpstream, plus BackendTrafficPolicy) to match what `make helm-build-crds` produces from the controller branch, and bumps the chart version.

Only the `scheme` blocks are touched; the rest of the bundle is left as-is and will be refreshed by the next controller bump.

Note on API7 EE: the Control Plane previously narrowed the stream upstream scheme to `tcp`/`udp`; `tls` is being enabled in api7/api7ee-3-control-plane#2869. Until a Control Plane image with that change is available, `scheme: tls` is usable against the APISIX provider only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for TCP, TLS, and UDP upstream schemes in ingress configuration.
  * Extended protocol options for port-level upstream settings and backend traffic policies.
  * Clarified that Layer 4 protocols apply to stream routes and are not valid for HTTP routes.

* **Chores**
  * Updated the ingress controller chart version to 0.1.25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->