### PR TITLE
release(aisix): 0.7.0

### DIFF
--- a/charts/aisix-cp/Chart.yaml
+++ b/charts/aisix-cp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix-cp
 description: Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 type: application
-version: 0.6.0
-appVersion: "0.6.0"
+version: 0.7.0
+appVersion: "0.7.0"
 
 maintainers:
   - name: API7

--- a/charts/aisix-cp/README.md
+++ b/charts/aisix-cp/README.md
@@ -1,6 +1,6 @@
 # aisix-cp
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 

--- a/charts/aisix/Chart.yaml
+++ b/charts/aisix/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix
 description: Helm chart for the AISIX AI gateway data plane
 type: application
-version: 0.6.0
-appVersion: "0.6.0"
+version: 0.7.0
+appVersion: "0.7.0"
 
 keywords:
   - ai-gateway

--- a/charts/aisix/README.md
+++ b/charts/aisix/README.md
@@ -1,6 +1,6 @@
 # aisix
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 Helm chart for the AISIX AI gateway data plane
 

--- a/charts/aisix/templates/deployment.yaml
+++ b/charts/aisix/templates/deployment.yaml
@@ -123,21 +123,21 @@ spec:
             failureThreshold: {{ .Values.startupProbe.failureThreshold }}
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
-          # /status/ready on the metrics listener is the configuration-source
-          # readiness gate: 503 until the control plane's configuration has
-          # been applied, 200 from then on. A replica the autoscaler adds
-          # therefore joins the Service only once it can actually serve.
+          # /readyz answers 503 while the instance is draining or before the
+          # control plane's configuration has been applied, 200 from then on.
+          # A replica the autoscaler adds therefore joins the Service only
+          # once it can actually serve, and leaves it as soon as it starts
+          # draining — both measured on the listener that carries the traffic.
           #
-          # Not the proxy listener's /readyz: up to and including the
-          # appVersion this chart pins, that one also withdraws an instance
-          # whose configuration watch has gone five minutes without an event,
-          # which an idle environment does routinely — every replica leaves
-          # the Service while perfectly healthy. Fixed in api7/aisix#841;
-          # switch this probe to /readyz once appVersion carries that fix.
+          # It no longer withdraws an instance whose configuration watch has
+          # merely gone quiet, which an idle environment does routinely and
+          # which used to empty the Service of every healthy replica at once
+          # (api7/aisix#841, shipped in appVersion 0.7.0). Configuration
+          # freshness stays visible on /status/config and aisix_config_*.
           readinessProbe:
             httpGet:
-              path: /status/ready
-              port: metrics
+              path: /readyz
+              port: proxy
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           {{- end }}


### PR DESCRIPTION
Releases the `aisix-cp` (control plane) and `aisix` (data plane) charts at 0.7.0. Both carry the same `version` and `appVersion`, and `appVersion` pins the images published for this release: `docker.io/api7/aisix-cp-{api,dpm,ui}:0.7.0` and `docker.io/api7/aisix:0.7.0`.

## aisix-cp

Version bump plus the regenerated README, nothing else. The control-plane source-of-truth chart saw no changes this cycle, so there is no functional delta to sync. The public adaptations are preserved: `docker.io` registries, an empty `tag` resolving to `.Chart.AppVersion`, `api.dpImage` defaulting to `docker.io/api7/aisix:<appVersion>`, and the README.

## aisix

Version bump, plus the readiness probe moves from `/status/ready` on the metrics listener to `/readyz` on the proxy listener.

`/readyz` previously returned 503 once the configuration watch had gone five minutes without an event. That measures elapsed time since the last configuration *event*, which an environment whose resources are not changing does not produce — so every replica crossed the threshold simultaneously and the Service lost all its endpoints while perfectly healthy. The chart worked around it by probing `/status/ready` on the metrics port instead. api7/aisix#841 removed that condition and ships in appVersion 0.7.0, so readiness returns to the listener that actually carries the traffic.

Verified with `helm lint` and `helm template` on both charts: the three control-plane images and `AISIX_CLOUD_DP_IMAGE` resolve to `docker.io/...:0.7.0`, and the data-plane probe renders as `/readyz` on `proxy`.

Merging publishes `aisix-cp-0.7.0` and `aisix-0.7.0` to charts.api7.ai.