### PR TITLE
release(aisix): 0.7.1

### DIFF
--- a/charts/aisix-cp/Chart.yaml
+++ b/charts/aisix-cp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix-cp
 description: Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 type: application
-version: 0.7.0
-appVersion: "0.7.0"
+version: 0.7.1
+appVersion: "0.7.1"
 
 maintainers:
   - name: API7

--- a/charts/aisix-cp/README.md
+++ b/charts/aisix-cp/README.md
@@ -1,6 +1,6 @@
 # aisix-cp
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.1](https://img.shields.io/badge/AppVersion-0.7.1-informational?style=flat-square)
 
 Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 

--- a/charts/aisix-cp/templates/dpm-deployment.yaml
+++ b/charts/aisix-cp/templates/dpm-deployment.yaml
@@ -51,6 +51,13 @@ spec:
               value: ":7944"
             - name: AISIX_DPMGR_HEALTH_LISTEN
               value: {{ .Values.dpm.service.healthListen | quote }}
+            {{- if .Values.api.dpmgrBaseURL }}
+            # Same value cp-api bakes into the install snippet: dp-manager
+            # seeds its TLS server cert SANs from this host, so a DP that
+            # dials the CP by IP can complete the handshake (#1216).
+            - name: AISIX_DPMGR_BASE_URL
+              value: {{ .Values.api.dpmgrBaseURL | quote }}
+            {{- end }}
             - name: AISIX_DPMGR_DATABASE_URL
               value: {{ include "aisix-cp.databaseURL" . }}
             - name: AISIX_DPMGR_MASTER_KEY

--- a/charts/aisix-cp/values.yaml
+++ b/charts/aisix-cp/values.yaml
@@ -38,6 +38,10 @@ api:
   affinity: {}
   extraEnvVars: []
   publicBaseURL: "http://localhost:8080"
+  ## dp-manager /dp/* mTLS endpoint that data-plane hosts dial, as baked
+  ## into the generated install snippets. Also passed to the dpm
+  ## deployment, which seeds this host into the TLS server certificate it
+  ## presents — so an IP address works here, not only a DNS name.
   dpmgrBaseURL: ""
   oauthEnabled: false
   dpImage: ""  # empty -> docker.io/api7/aisix:<appVersion>

--- a/charts/aisix/Chart.yaml
+++ b/charts/aisix/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix
 description: Helm chart for the AISIX AI gateway data plane
 type: application
-version: 0.7.0
-appVersion: "0.7.0"
+version: 0.7.1
+appVersion: "0.7.1"
 
 keywords:
   - ai-gateway

--- a/charts/aisix/README.md
+++ b/charts/aisix/README.md
@@ -1,6 +1,6 @@
 # aisix
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.1](https://img.shields.io/badge/AppVersion-0.7.1-informational?style=flat-square)
 
 Helm chart for the AISIX AI gateway data plane
 


### PR DESCRIPTION
Releases `aisix-cp` and `aisix` 0.7.1. Both charts move together, since `appVersion` pins the image tag on each side and a control plane and data plane from different releases is not a combination we ship.

## Version bump

`version` and `appVersion` to `0.7.1` on both charts, and regenerated READMEs. The images the new `appVersion` resolves to are published: `docker.io/api7/aisix:0.7.1` and `docker.io/api7/aisix-cp-{api,dpm,ui}:0.7.1`.

## Synced delta (aisix-cp)

One functional change accumulated in the control-plane source chart since 0.7.0: `dp-manager` now receives `AISIX_DPMGR_BASE_URL`, gated on `api.dpmgrBaseURL` being set. It seeds the subject alternative names of the TLS server certificate `dp-manager` presents, so a data plane that dials the control plane by IP address can complete the handshake. Without this the value reached only `cp-api`, which bakes it into the generated install snippet, and a remote data plane addressed by IP looped forever on `certificate not valid for name`.

The `values.yaml` comment on `api.dpmgrBaseURL` is synced along with it; the key itself already existed.

## Preserved public adaptations

The sync leaves the public chart's intentional divergences intact: `docker.io` registries, empty image tags defaulting to `.Chart.AppVersion`, the always-emitted `api.dpImage` default, and the generated `README.md`. After this change the only remaining diff against the control-plane source chart is exactly that set.

## Data-plane chart

`charts/aisix` is authored here and has no source chart to sync from, so it takes the version and `appVersion` bump only.

## Verification

`helm lint` passes on both charts. Rendering `aisix-cp` resolves every image to `docker.io/api7/aisix-cp-*:0.7.1` and `AISIX_CLOUD_DP_IMAGE` to `docker.io/api7/aisix:0.7.1`; the new environment variable renders when `api.dpmgrBaseURL` is set and is absent when it is not. Rendering `aisix` resolves the gateway image to `docker.io/api7/aisix:0.7.1`.

Merging publishes `aisix-cp-0.7.1` and `aisix-0.7.1` to charts.api7.ai.