### PR TITLE
feat(api7): support extraEnvVars for file server

### DIFF
--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.10.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.10.3
+version: 3.10.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -1,6 +1,6 @@
 # api7ee3
 
-![Version: 3.10.3](https://img.shields.io/badge/Version-3.10.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.10.4](https://img.shields.io/badge/AppVersion-3.10.4-informational?style=flat-square)
+![Version: 3.10.4](https://img.shields.io/badge/Version-3.10.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.10.4](https://img.shields.io/badge/AppVersion-3.10.4-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -235,6 +235,7 @@ A Helm chart for Kubernetes
 | dp_manager_service.tlsPort | int | `7943` |  |
 | dp_manager_service.type | string | `"ClusterIP"` |  |
 | file_server.enabled | bool | `false` |  |
+| file_server.extraEnvVars | list | `[]` |  |
 | file_server.image.pullPolicy | string | `"Always"` |  |
 | file_server.image.repository | string | `"api7/api7-ee-file-server"` |  |
 | file_server.image.tag | string | `"v3.10.4"` |  |

--- a/charts/api7/templates/file-server-deploy.yaml
+++ b/charts/api7/templates/file-server-deploy.yaml
@@ -63,6 +63,10 @@ spec:
             initialDelaySeconds: {{ .Values.file_server.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.file_server.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.file_server.readinessProbe.failureThreshold }}
+          {{- if .Values.file_server.extraEnvVars }}
+          env:
+          {{- include "api7ee3.tplvalues.render" (dict "value" .Values.file_server.extraEnvVars "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /usr/local/api7/conf

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -93,6 +93,8 @@ file_server:
     repository: api7/api7-ee-file-server
     pullPolicy: Always
     tag: "v3.10.4"
+
+  extraEnvVars: []
   livenessProbe:
     initialDelaySeconds: 60
     periodSeconds: 3


### PR DESCRIPTION
Fixes #332

`file_server` was the only deployment in the `api7ee3` chart with no way to inject environment variables — `dashboard`, `dp_manager`, `developer_portal` and `api_usage` all expose `extraEnvVars`.

Adds `file_server.extraEnvVars` (default `[]`) and renders it in `file-server-deploy.yaml`. The list goes through `api7ee3.tplvalues.render`, so entries may contain templates and `valueFrom` references, matching the other components. The whole `env:` block is guarded by the `if`, so the rendered Deployment is byte-identical to before when the value is left empty.

```yaml
file_server:
  enabled: true
  extraEnvVars:
    - name: API7_LOG_LEVEL
      value: debug
    - name: RELEASE_NS
      value: "{{ .Release.Namespace }}"
    - name: FROM_SECRET
      valueFrom:
        secretKeyRef:
          name: my-secret
          key: token
```

Chart version 3.10.3 -> 3.10.4, README regenerated with helm-docs.

A parallel PR targets `release/3.9` for the 3.9 line.