### PR TITLE
chore(api7): sync values comments from the upstream chart

### DIFF
--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -428,6 +428,8 @@ dashboard_configuration:
     #       url: "https://docs.api7.ai"
   audit:
     retention_days: 60
+
+  # the following configuration takes effect for the gateway
   consumer_proxy:
     enable: false
     cache_success_count: 512
@@ -465,7 +467,8 @@ dashboard_configuration:
   #     resource_container: yaml
   #     config_container: config
   #     endpoint: "$YOUR_AZURE_BLOB_ENDPOINT"
-
+  # model_catalog_source_endpoint: "https://models.dev/api.json" # URL of the upstream model catalog; leave empty to disable sync
+  # model_catalog_sync_interval: 0   # Periodic sync interval in seconds (0 = disabled; minimum 60; e.g. 3600 = 1h, 86400 = 24h)
   security:
     # content_security_policy: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
 


### PR DESCRIPTION
`charts/api7` is the downstream copy of `api7/api7ee-3-control-plane` `helm/`, and two documented options never made it across: the `model_catalog_source_endpoint` / `model_catalog_sync_interval` examples, and the comment marking which part of `dashboard_configuration` applies to the gateway.

Comments only — no rendered output changes, so no chart version bump and `helm-docs` produces no README diff.

`main` only: model catalog sync ships in 3.10 (the CP commit is reachable from `v3.10.0` and no earlier tag), so the keys would be misleading on `release/3.9`.

The reverse direction — options that only existed here and are now being ported back upstream — is api7/api7ee-3-control-plane#2890.