### PR TITLE
release(aisix): 0.8.0

### DIFF
--- a/charts/aisix-cp/Chart.yaml
+++ b/charts/aisix-cp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix-cp
 description: Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 type: application
-version: 0.7.1
-appVersion: "0.7.1"
+version: 0.8.0
+appVersion: "0.8.0"
 
 maintainers:
   - name: API7

--- a/charts/aisix-cp/README.md
+++ b/charts/aisix-cp/README.md
@@ -1,6 +1,6 @@
 # aisix-cp
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.1](https://img.shields.io/badge/AppVersion-0.7.1-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
 
 Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 

--- a/charts/aisix-cp/values.yaml
+++ b/charts/aisix-cp/values.yaml
@@ -47,12 +47,12 @@ api:
   dpImage: ""  # empty -> docker.io/api7/aisix:<appVersion>
   ## Allow the dashboard playground to reach LLM endpoints on private /
   ## internal networks. cp-api blocks private IPs by default (SSRF guard);
-  ## enable this only for self-hosted deployments whose models live on an
+  ## enable this only for On-Premises deployments whose models live on an
   ## internal network the cp-api pod can route to.
   playgroundAllowPrivateIPs: false
   ## Allow notification channels (budget alert webhooks / Slack) to point
   ## at private / internal addresses. Blocked by default (SSRF guard);
-  ## enable only for self-hosted deployments whose webhook receivers live
+  ## enable only for On-Premises deployments whose webhook receivers live
   ## on an intranet the cp-api pod can route to.
   notifyAllowPrivateURLs: false
 

--- a/charts/aisix/Chart.yaml
+++ b/charts/aisix/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix
 description: Helm chart for the AISIX AI gateway data plane
 type: application
-version: 0.7.1
-appVersion: "0.7.1"
+version: 0.8.0
+appVersion: "0.8.0"
 
 keywords:
   - ai-gateway

--- a/charts/aisix/README.md
+++ b/charts/aisix/README.md
@@ -1,6 +1,6 @@
 # aisix
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.1](https://img.shields.io/badge/AppVersion-0.7.1-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
 
 Helm chart for the AISIX AI gateway data plane
 


### PR DESCRIPTION
Releases the AISIX AI Gateway 0.8.0 charts.

- `charts/aisix-cp` and `charts/aisix`: `version` and `appVersion` → `0.8.0`. `appVersion` pins the image tags, so the charts install `docker.io/api7/aisix-cp-{api,dpm,ui}:0.8.0` and `docker.io/api7/aisix:0.8.0` — all four images are already published.
- Synced from the control-plane source-of-truth chart: the product-terminology change to the two SSRF-guard comments in `aisix-cp/values.yaml` (`self-hosted` → `On-Premises`). That is the only functional delta accumulated since 0.7.1.
- `README.md` regenerated by `helm-docs`.

Preserves the public adaptations: `docker.io` registries, empty image tags resolving to `.Chart.AppVersion`, the always-emitted `api.dpImage` default, and the public-only `README.md`.

Merging publishes `aisix-cp-0.8.0` and `aisix-0.8.0` to https://charts.api7.ai.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the AISIX and AISIX Control Plane Helm charts and application versions to 0.8.0.
  - Updated chart documentation badges to reflect the 0.8.0 release.

- **Documentation**
  - Clarified deployment guidance by referring to “On-Premises” environments instead of “self-hosted” environments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->