### PR TITLE
release(aisix): 0.8.1

### DIFF
--- a/charts/aisix-cp/Chart.yaml
+++ b/charts/aisix-cp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix-cp
 description: Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 type: application
-version: 0.8.0
-appVersion: "0.8.0"
+version: 0.8.1
+appVersion: "0.8.1"
 
 maintainers:
   - name: API7

--- a/charts/aisix-cp/README.md
+++ b/charts/aisix-cp/README.md
@@ -1,6 +1,6 @@
 # aisix-cp
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
 
 Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 

--- a/charts/aisix/Chart.yaml
+++ b/charts/aisix/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix
 description: Helm chart for the AISIX AI gateway data plane
 type: application
-version: 0.8.0
-appVersion: "0.8.0"
+version: 0.8.1
+appVersion: "0.8.1"
 
 keywords:
   - ai-gateway

--- a/charts/aisix/README.md
+++ b/charts/aisix/README.md
@@ -1,6 +1,6 @@
 # aisix
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
 
 Helm chart for the AISIX AI gateway data plane
 


### PR DESCRIPTION
Bumps `charts/aisix-cp` and `charts/aisix` to `0.8.1` (both `version` and `appVersion`) and regenerates the READMEs.

`appVersion` pins the image tags, and the images are published:

- `docker.io/api7/aisix:0.8.1`
- `docker.io/api7/aisix-cp-api:0.8.1`
- `docker.io/api7/aisix-cp-dpm:0.8.1`
- `docker.io/api7/aisix-cp-ui:0.8.1`

## Sync

Nothing functional to carry over this cycle — `control-plane/helm/aisix-cp` saw no changes between `v0.8.0` and `v0.8.1`. The residual diff against it is only the public adaptations this chart keeps on purpose: `docker.io` registries, the empty `tag` defaulting to `.Chart.AppVersion`, the always-emitted `api.dpImage` default, and the README.

## Verification

`helm lint` passes for both charts, and `helm template` resolves every image to its published `0.8.1` tag.

Merging publishes `aisix-cp-0.8.1` and `aisix-0.8.1` to charts.api7.ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AISIX and AISIX control-plane Helm charts to version 0.8.1.
  * Updated associated application version references and documentation badges to reflect the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->