### PR TITLE
release(aisix): 0.8.2

### DIFF
--- a/charts/aisix-cp/Chart.yaml
+++ b/charts/aisix-cp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix-cp
 description: Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 type: application
-version: 0.8.1
-appVersion: "0.8.1"
+version: 0.8.2
+appVersion: "0.8.2"
 
 maintainers:
   - name: API7

--- a/charts/aisix-cp/README.md
+++ b/charts/aisix-cp/README.md
@@ -1,6 +1,6 @@
 # aisix-cp
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
+![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
 
 Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 

--- a/charts/aisix/Chart.yaml
+++ b/charts/aisix/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix
 description: Helm chart for the AISIX AI gateway data plane
 type: application
-version: 0.8.1
-appVersion: "0.8.1"
+version: 0.8.2
+appVersion: "0.8.2"
 
 keywords:
   - ai-gateway

--- a/charts/aisix/README.md
+++ b/charts/aisix/README.md
@@ -1,6 +1,6 @@
 # aisix
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
+![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
 
 Helm chart for the AISIX AI gateway data plane
 


### PR DESCRIPTION
Publishes the 0.8.2 charts.

- `charts/aisix-cp` and `charts/aisix`: `version` and `appVersion` → `0.8.2`, READMEs regenerated.
- No template or values changes this cycle. Diffing the control-plane chart at the 0.8.2 release tree against this one leaves only the intended public adaptations: `docker.io` registries, empty `tag` / `api.dpImage` defaults that resolve from `appVersion`, and this repo's `README.md`.
- `appVersion` pins the image tags, and all four are published: `docker.io/api7/aisix:0.8.2`, `docker.io/api7/aisix-cp-{api,dpm,ui}:0.8.2`.

Rendering check: `aisix-cp` resolves its three images and `AISIX_CLOUD_DP_IMAGE` to `:0.8.2`; `aisix` resolves the gateway image to `docker.io/api7/aisix:0.8.2`. Both charts lint clean.

Merging publishes `aisix-cp-0.8.2` and `aisix-0.8.2` to charts.api7.ai.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AISIX and AISIX Control Plane Helm charts to version 0.8.2.
  * Refreshed published chart and application version information in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->