### PR TITLE
chore: upgrade api7 and gateway to v3.10.5

### DIFF
--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.10.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.10.4
+version: 3.10.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.10.4"
+appVersion: "3.10.5"
 
 maintainers:
   - name: API7

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -1,6 +1,6 @@
 # api7ee3
 
-![Version: 3.10.4](https://img.shields.io/badge/Version-3.10.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.10.4](https://img.shields.io/badge/AppVersion-3.10.4-informational?style=flat-square)
+![Version: 3.10.5](https://img.shields.io/badge/Version-3.10.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.10.5](https://img.shields.io/badge/AppVersion-3.10.5-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -29,7 +29,7 @@ A Helm chart for Kubernetes
 | dashboard.extraVolumes | list | `[]` |  |
 | dashboard.image.pullPolicy | string | `"Always"` |  |
 | dashboard.image.repository | string | `"api7/api7-ee-3-integrated"` |  |
-| dashboard.image.tag | string | `"v3.10.4"` |  |
+| dashboard.image.tag | string | `"v3.10.5"` |  |
 | dashboard.keyCertSecret | string | `""` |  |
 | dashboard.livenessProbe.failureThreshold | int | `30` |  |
 | dashboard.livenessProbe.initialDelaySeconds | int | `180` |  |
@@ -123,7 +123,7 @@ A Helm chart for Kubernetes
 | developer_portal.extraVolumes | list | `[]` |  |
 | developer_portal.image.pullPolicy | string | `"Always"` |  |
 | developer_portal.image.repository | string | `"api7/api7-ee-developer-portal"` |  |
-| developer_portal.image.tag | string | `"v3.10.4"` |  |
+| developer_portal.image.tag | string | `"v3.10.5"` |  |
 | developer_portal.keyCertSecret | string | `""` |  |
 | developer_portal.livenessProbe.failureThreshold | int | `10` |  |
 | developer_portal.livenessProbe.initialDelaySeconds | int | `60` |  |
@@ -143,6 +143,9 @@ A Helm chart for Kubernetes
 | developer_portal_configuration.log.access_log | string | `"stdout"` |  |
 | developer_portal_configuration.log.level | string | `"warn"` | Allowed values: `debug`, `info`, `warn`, `error` |
 | developer_portal_configuration.log.output | string | `"stderr"` |  |
+| developer_portal_configuration.security.ssrf_protection | object | `{"allow_list":[],"deny_list":[],"enable":false}` | ssrf_protection restricts the destinations the developer portal connects to when it requests a user-configured network endpoint (approval webhooks, the DCR client registration bridge). Disabled by default so internal endpoints keep working; enable to block SSRF to internal, loopback, link-local and cloud-metadata addresses. |
+| developer_portal_configuration.security.ssrf_protection.allow_list | list | `[]` | CIDRs always permitted even if otherwise internal |
+| developer_portal_configuration.security.ssrf_protection.deny_list | list | `[]` | extra CIDRs to block on top of the built-in internal ranges |
 | developer_portal_configuration.server.listen.host | string | `"0.0.0.0"` |  |
 | developer_portal_configuration.server.listen.port | int | `4321` |  |
 | developer_portal_configuration.server.listen.tls.cert_file | string | `""` |  |
@@ -170,7 +173,7 @@ A Helm chart for Kubernetes
 | dp_manager.extraVolumes | list | `[]` |  |
 | dp_manager.image.pullPolicy | string | `"Always"` |  |
 | dp_manager.image.repository | string | `"api7/api7-ee-dp-manager"` |  |
-| dp_manager.image.tag | string | `"v3.10.4"` |  |
+| dp_manager.image.tag | string | `"v3.10.5"` |  |
 | dp_manager.livenessProbe.failureThreshold | int | `10` |  |
 | dp_manager.livenessProbe.initialDelaySeconds | int | `60` |  |
 | dp_manager.livenessProbe.periodSeconds | int | `3` |  |
@@ -238,7 +241,7 @@ A Helm chart for Kubernetes
 | file_server.extraEnvVars | list | `[]` |  |
 | file_server.image.pullPolicy | string | `"Always"` |  |
 | file_server.image.repository | string | `"api7/api7-ee-file-server"` |  |
-| file_server.image.tag | string | `"v3.10.4"` |  |
+| file_server.image.tag | string | `"v3.10.5"` |  |
 | file_server.livenessProbe.failureThreshold | int | `10` |  |
 | file_server.livenessProbe.initialDelaySeconds | int | `60` |  |
 | file_server.livenessProbe.periodSeconds | int | `3` |  |

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -18,7 +18,7 @@ dashboard:
     repository: api7/api7-ee-3-integrated
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.10.4"
+    tag: "v3.10.5"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -55,7 +55,7 @@ dp_manager:
     repository: api7/api7-ee-dp-manager
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.10.4"
+    tag: "v3.10.5"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -92,7 +92,7 @@ file_server:
   image:
     repository: api7/api7-ee-file-server
     pullPolicy: Always
-    tag: "v3.10.4"
+    tag: "v3.10.5"
 
   extraEnvVars: []
   livenessProbe:
@@ -112,7 +112,7 @@ developer_portal:
     repository: api7/api7-ee-developer-portal
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.10.4"
+    tag: "v3.10.5"
 
   extraEnvVars: []
   extraVolumes: []
@@ -615,6 +615,17 @@ developer_portal_configuration:
     #   tls:
     #     ca_cert: ""
     #     insecure: false
+  security:
+    # -- ssrf_protection restricts the destinations the developer portal connects to when it
+    # requests a user-configured network endpoint (approval webhooks, the DCR client
+    # registration bridge). Disabled by default so internal endpoints keep working; enable to
+    # block SSRF to internal, loopback, link-local and cloud-metadata addresses.
+    ssrf_protection:
+      enable: false
+      # -- CIDRs always permitted even if otherwise internal
+      allow_list: []
+      # -- extra CIDRs to block on top of the built-in internal ranges
+      deny_list: []
 
 file_server_configuration:
   file_server:

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -16,12 +16,12 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.10.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.10.10
+version: 3.10.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "3.10.4"
+appVersion: "3.10.5"
 
 maintainers:
   - name: API7

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -158,7 +158,7 @@ apisix:
 | apisix.httpRouter | string | `"radixtree_host_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
 | apisix.image.pullPolicy | string | `"Always"` | API7 Gateway image pull policy |
 | apisix.image.repository | string | `"api7/api7-ee-3-gateway"` | API7 Gateway image repository |
-| apisix.image.tag | string | `"3.10.4"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
+| apisix.image.tag | string | `"3.10.5"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
 | apisix.kind | string | `"Deployment"` | Use a `DaemonSet` or `Deployment` |
 | apisix.lru | object | `{"secret":{"count":512,"neg_count":512,"neg_ttl":60,"ttl":300}}` | fine tune the parameters of LRU cache for some features like secret |
 | apisix.lru.secret.count | int | `512` | Maximum number of cached secret values |

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -205,7 +205,7 @@ apisix:
     pullPolicy: Always
     # -- API7 Gateway image tag
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.10.4
+    tag: 3.10.5
 
   # -- Use a `DaemonSet` or `Deployment`
   kind: Deployment


### PR DESCRIPTION
## Version bumps

| Chart | version | appVersion | images |
| --- | --- | --- | --- |
| `charts/api7` | 3.10.4 → 3.10.5 | 3.10.5 | dashboard, dp_manager, developer_portal, file_server → `v3.10.5` |
| `charts/gateway` | 3.10.10 → 3.10.11 | 3.10.5 | gateway → `3.10.5` |

## Structural change

`developer_portal_configuration.security.ssrf_protection`, synced from the control plane's `helm/values.yaml`. The developer portal process now installs the SSRF guard (api7/api7ee-3-control-plane#2897); before that the setting existed only for the dashboard, so enabling it had no effect on the portal's outbound calls (approval webhooks and DCR client registration). The chart therefore has to expose the policy the portal reads. It stays disabled by default, so behavior is unchanged. `developer-portal-configmap.yaml` forwards the whole map through `toYaml`, so no template change is needed.

The rest of the control plane's chart changes in this range are already present here — `extraInitContainers`, `file_server.extraEnvVars` and the `file_server_service` nodePort example were reconciled upstream against this copy (#2890), and the model catalog keys removed by #2891 were never carried downstream.

The only gateway `config-default.yaml` change in this range adds `ldap-auth-advanced` to the plugin list, which this chart does not manage.

## Verification

- `helm lint` clean on both charts.
- The rendered developer portal configmap carries the new block in both states — absent override (`enable: false`) and `--set developer_portal_configuration.security.ssrf_protection.enable=true`.
- The rendered gateway `config.yaml` passes `apisix init` inside `api7/api7-ee-3-gateway:3.10.5`.
- `values.yaml` parses with a duplicate-key-raising YAML loader, so the new `security:` block does not shadow an existing key.
- READMEs regenerated with `make helm-docs`.

Release notes: api7/docs#2074.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional developer portal SSRF protection with configurable allowed and denied network ranges. Protection is disabled by default.

* **Updates**
  * Updated API7 Gateway, dashboard, developer portal, DP manager, and file server components to version 3.10.5.
  * Updated Helm chart versions and documented default image versions accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->