### PR TITLE
chore: upgrade api7 and gateway to v3.9.18

### DIFF
--- a/charts/api7/Chart.yaml
+++ b/charts/api7/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.9.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.9.4
+version: 3.9.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.9.17"
+appVersion: "3.9.18"
 
 maintainers:
   - name: API7

--- a/charts/api7/README.md
+++ b/charts/api7/README.md
@@ -1,6 +1,6 @@
 # api7ee3
 
-![Version: 3.9.4](https://img.shields.io/badge/Version-3.9.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.17](https://img.shields.io/badge/AppVersion-3.9.17-informational?style=flat-square)
+![Version: 3.9.5](https://img.shields.io/badge/Version-3.9.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.18](https://img.shields.io/badge/AppVersion-3.9.18-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -29,7 +29,7 @@ A Helm chart for Kubernetes
 | dashboard.extraVolumes | list | `[]` |  |
 | dashboard.image.pullPolicy | string | `"Always"` |  |
 | dashboard.image.repository | string | `"api7/api7-ee-3-integrated"` |  |
-| dashboard.image.tag | string | `"v3.9.17"` |  |
+| dashboard.image.tag | string | `"v3.9.18"` |  |
 | dashboard.keyCertSecret | string | `""` |  |
 | dashboard.livenessProbe.failureThreshold | int | `30` |  |
 | dashboard.livenessProbe.initialDelaySeconds | int | `180` |  |
@@ -123,7 +123,7 @@ A Helm chart for Kubernetes
 | developer_portal.extraVolumes | list | `[]` |  |
 | developer_portal.image.pullPolicy | string | `"Always"` |  |
 | developer_portal.image.repository | string | `"api7/api7-ee-developer-portal"` |  |
-| developer_portal.image.tag | string | `"v3.9.17"` |  |
+| developer_portal.image.tag | string | `"v3.9.18"` |  |
 | developer_portal.keyCertSecret | string | `""` |  |
 | developer_portal.livenessProbe.failureThreshold | int | `10` |  |
 | developer_portal.livenessProbe.initialDelaySeconds | int | `60` |  |
@@ -143,6 +143,9 @@ A Helm chart for Kubernetes
 | developer_portal_configuration.log.access_log | string | `"stdout"` |  |
 | developer_portal_configuration.log.level | string | `"warn"` | Allowed values: `debug`, `info`, `warn`, `error` |
 | developer_portal_configuration.log.output | string | `"stderr"` |  |
+| developer_portal_configuration.security.ssrf_protection | object | `{"allow_list":[],"deny_list":[],"enable":false}` | ssrf_protection restricts the destinations the developer portal connects to when it requests a user-configured network endpoint (approval webhooks, the DCR client registration bridge). Disabled by default so internal endpoints keep working; enable to block SSRF to internal, loopback, link-local and cloud-metadata addresses. |
+| developer_portal_configuration.security.ssrf_protection.allow_list | list | `[]` | CIDRs always permitted even if otherwise internal |
+| developer_portal_configuration.security.ssrf_protection.deny_list | list | `[]` | extra CIDRs to block on top of the built-in internal ranges |
 | developer_portal_configuration.server.listen.host | string | `"0.0.0.0"` |  |
 | developer_portal_configuration.server.listen.port | int | `4321` |  |
 | developer_portal_configuration.server.listen.tls.cert_file | string | `""` |  |
@@ -170,7 +173,7 @@ A Helm chart for Kubernetes
 | dp_manager.extraVolumes | list | `[]` |  |
 | dp_manager.image.pullPolicy | string | `"Always"` |  |
 | dp_manager.image.repository | string | `"api7/api7-ee-dp-manager"` |  |
-| dp_manager.image.tag | string | `"v3.9.17"` |  |
+| dp_manager.image.tag | string | `"v3.9.18"` |  |
 | dp_manager.livenessProbe.failureThreshold | int | `10` |  |
 | dp_manager.livenessProbe.initialDelaySeconds | int | `60` |  |
 | dp_manager.livenessProbe.periodSeconds | int | `3` |  |
@@ -238,7 +241,7 @@ A Helm chart for Kubernetes
 | file_server.extraEnvVars | list | `[]` |  |
 | file_server.image.pullPolicy | string | `"Always"` |  |
 | file_server.image.repository | string | `"api7/api7-ee-file-server"` |  |
-| file_server.image.tag | string | `"v3.9.17"` |  |
+| file_server.image.tag | string | `"v3.9.18"` |  |
 | file_server.livenessProbe.failureThreshold | int | `10` |  |
 | file_server.livenessProbe.initialDelaySeconds | int | `60` |  |
 | file_server.livenessProbe.periodSeconds | int | `3` |  |

--- a/charts/api7/values.yaml
+++ b/charts/api7/values.yaml
@@ -18,7 +18,7 @@ dashboard:
     repository: api7/api7-ee-3-integrated
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.17"
+    tag: "v3.9.18"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -55,7 +55,7 @@ dp_manager:
     repository: api7/api7-ee-dp-manager
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.17"
+    tag: "v3.9.18"
   # Resources of the deployment.
   # It has a higher priority than the common resources configuration:
   # when this field is configured, it is used first in the deployment,
@@ -92,7 +92,7 @@ file_server:
   image:
     repository: api7/api7-ee-file-server
     pullPolicy: Always
-    tag: "v3.9.17"
+    tag: "v3.9.18"
 
   extraEnvVars: []
   livenessProbe:
@@ -112,7 +112,7 @@ developer_portal:
     repository: api7/api7-ee-developer-portal
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "v3.9.17"
+    tag: "v3.9.18"
 
   extraEnvVars: []
   extraVolumes: []
@@ -615,6 +615,17 @@ developer_portal_configuration:
     #   tls:
     #     ca_cert: ""
     #     insecure: false
+  security:
+    # -- ssrf_protection restricts the destinations the developer portal connects to when it
+    # requests a user-configured network endpoint (approval webhooks, the DCR client
+    # registration bridge). Disabled by default so internal endpoints keep working; enable to
+    # block SSRF to internal, loopback, link-local and cloud-metadata addresses.
+    ssrf_protection:
+      enable: false
+      # -- CIDRs always permitted even if otherwise internal
+      allow_list: []
+      # -- extra CIDRs to block on top of the built-in internal ranges
+      deny_list: []
 
 file_server_configuration:
   file_server:

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -16,12 +16,12 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # major.minor mirrors the API7 EE release line (3.9.x), patch is this chart's
 # own counter on that line and is decoupled from the app patch (see appVersion).
-version: 3.9.8
+version: 3.9.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "3.9.17"
+appVersion: "3.9.18"
 
 maintainers:
   - name: API7

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -178,7 +178,7 @@ apisix:
 | apisix.httpRouter | string | `"radixtree_host_uri"` | Defines how apisix handles routing: - radixtree_uri: match route by uri(base on radixtree) - radixtree_host_uri: match route by host + uri(base on radixtree) - radixtree_uri_with_parameter: match route by uri with parameters |
 | apisix.image.pullPolicy | string | `"Always"` | API7 Gateway image pull policy |
 | apisix.image.repository | string | `"api7/api7-ee-3-gateway"` | API7 Gateway image repository |
-| apisix.image.tag | string | `"3.9.17"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
+| apisix.image.tag | string | `"3.9.18"` | API7 Gateway image tag Overrides the image tag whose default is the chart appVersion. |
 | apisix.kind | string | `"Deployment"` | Use a `DaemonSet` or `Deployment` |
 | apisix.lru | object | `{"secret":{"count":512,"neg_count":512,"neg_ttl":60,"ttl":300}}` | fine tune the parameters of LRU cache for some features like secret |
 | apisix.lru.secret.neg_ttl | int | `60` | in seconds |

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -137,7 +137,7 @@ apisix:
     pullPolicy: Always
     # -- API7 Gateway image tag
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.9.17
+    tag: 3.9.18
 
   # -- Use a `DaemonSet` or `Deployment`
   kind: Deployment


### PR DESCRIPTION
Chart release for API7 EE 3.9.18.

3.9.18 is a patch on the 3.9 line and 3.10 is the latest line, so this targets `release/3.9` rather than `main`.

## Version bumps

| chart | version | appVersion |
|---|---|---|
| `api7` | 3.9.4 → 3.9.5 | 3.9.17 → **3.9.18** |
| `gateway` | 3.9.8 → 3.9.9 | 3.9.17 → **3.9.18** |

Chart patches are each line's own counter, per the numbering rule in `AGENTS.md`. Image tags move to `v3.9.18` (dashboard, dp_manager, file_server, developer_portal) and `3.9.18` (gateway). `ingress-controller` and `developer-portal-fe` are left at their existing versions so `CR_SKIP_EXISTING` skips them.

## Structural change

Adds `developer_portal_configuration.security.ssrf_protection` to `charts/api7/values.yaml`, mirroring what the 3.10.5 chart exposed for the same Control Plane change (#341). 3.9.18 installs the SSRF guard in the developer portal process, so `security.ssrf_protection` has to be reachable from the chart or the setting has no effect there.

The default stays `enable: false`, so a default render is unchanged. Verified that it renders in both states, and that the existing `dashboard_configuration.security` block (`trusted_proxies`, `ip_restriction`) is untouched — the two `security:` keys sit under different parents.

## Not ported

The other Control Plane chart changes in the `v3.9.17..v3.9.18` range — `extraInitContainers`, the file server `nodePort` example, and the connection max-lifetime comment — came from reconciling the upstream copy against this chart and are already present here. The gateway's `conf/config-default.yaml` did not change in this range, so the gateway chart needs no structural update.

## Validation

`helm lint` passes on both charts, and the rendered gateway `config.yaml` was extracted from the ConfigMap and run through `apisix init` on `api7/api7-ee-3-gateway:3.9.18`, which validates it against the real config schema. `README.md` regenerated with `make helm-docs`.
