### PR TITLE
release(aisix): 0.9.0

### DIFF
--- a/charts/aisix-cp/Chart.yaml
+++ b/charts/aisix-cp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix-cp
 description: Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 type: application
-version: 0.8.2
-appVersion: "0.8.2"
+version: 0.9.0
+appVersion: "0.9.0"
 
 maintainers:
   - name: API7

--- a/charts/aisix-cp/Chart.yaml
+++ b/charts/aisix-cp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix-cp
 description: Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 type: application
-version: 0.8.1
-appVersion: "0.8.1"
+version: 0.8.2
+appVersion: "0.8.2"
 
 maintainers:
   - name: API7

--- a/charts/aisix-cp/README.md
+++ b/charts/aisix-cp/README.md
@@ -1,6 +1,6 @@
 # aisix-cp
 
-![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
 
 Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 
@@ -128,3 +128,4 @@ Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 | ui.service.type | string | `"ClusterIP"` |  |
 | ui.tolerations | list | `[]` |  |
 
+----------------------------------------------

--- a/charts/aisix-cp/README.md
+++ b/charts/aisix-cp/README.md
@@ -128,4 +128,3 @@ Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 | ui.service.type | string | `"ClusterIP"` |  |
 | ui.tolerations | list | `[]` |  |
 
-----------------------------------------------

--- a/charts/aisix-cp/README.md
+++ b/charts/aisix-cp/README.md
@@ -1,6 +1,6 @@
 # aisix-cp
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
+![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
 
 Helm chart for AISIX control plane (cp-api, dp-manager, dashboard)
 

--- a/charts/aisix-cp/templates/api-deployment.yaml
+++ b/charts/aisix-cp/templates/api-deployment.yaml
@@ -96,12 +96,25 @@ spec:
           # can outlast the liveness budget below and kill the pod
           # MID-MIGRATION. The startupProbe suspends liveness and
           # readiness until the server is actually up.
+          #
+          # 30 minutes, because a migration that REWRITES a table is
+          # bounded by table size, not by a fixed bootstrap cost. The
+          # 0.9.0 widening of dpmgr_usage_events.request_id (uuid ->
+          # text) measured 6m21s on 10M rows — roughly what 30 days of
+          # retention holds at a sustained 4 req/s — and it scales
+          # linearly from there. The previous 5-minute budget would have
+          # turned that upgrade into the exact crash loop this probe
+          # exists to prevent.
+          #
+          # The cost is that a genuinely wedged cp-api goes unrestarted
+          # for up to 30 minutes on FIRST start only; once the probe
+          # succeeds, the liveness budget below takes over unchanged.
           startupProbe:
             httpGet:
               path: /healthz
               port: http
             periodSeconds: 5
-            failureThreshold: 60
+            failureThreshold: 360
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/aisix/Chart.yaml
+++ b/charts/aisix/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix
 description: Helm chart for the AISIX AI gateway data plane
 type: application
-version: 0.8.1
-appVersion: "0.8.1"
+version: 0.8.2
+appVersion: "0.8.2"
 
 keywords:
   - ai-gateway

--- a/charts/aisix/Chart.yaml
+++ b/charts/aisix/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: aisix
 description: Helm chart for the AISIX AI gateway data plane
 type: application
-version: 0.8.2
-appVersion: "0.8.2"
+version: 0.9.0
+appVersion: "0.9.0"
 
 keywords:
   - ai-gateway

--- a/charts/aisix/README.md
+++ b/charts/aisix/README.md
@@ -1,6 +1,6 @@
 # aisix
 
-![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
 
 Helm chart for the AISIX AI gateway data plane
 

--- a/charts/aisix/README.md
+++ b/charts/aisix/README.md
@@ -1,6 +1,6 @@
 # aisix
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
+![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
 
 Helm chart for the AISIX AI gateway data plane
 


### PR DESCRIPTION
Bumps `aisix-cp` and `aisix` to `0.9.0` (`version` + `appVersion`), so both charts pin the 0.9.0 images now published to `docker.io/api7`.

## Synced from the control-plane chart

One functional delta accumulated this cycle: the cp-api **startupProbe budget goes from 5 minutes to 30** (`failureThreshold` 60 → 360).

0.9.0 widens `dpmgr_usage_events.request_id` from `uuid` to `text`. A migration that rewrites a table is bounded by table size, not by a fixed bootstrap cost — measured at 6m21s on 10M rows, roughly what 30 days of retention holds at a sustained 4 req/s. cp-api runs the migration before it binds `:8080`, so the old 5-minute budget would have let liveness kill the pod mid-migration: exactly the crash loop this probe exists to prevent. The cost is that a genuinely wedged cp-api goes unrestarted for up to 30 minutes on first start only.

## Preserved public adaptations

`docker.io` registries, empty image tags resolving to `.Chart.AppVersion`, the always-emit `api.dpImage` default, and the generated `README.md` files — all left divergent from the control-plane chart by design.

## Verification

`helm lint` clean on both charts; rendered output resolves to `docker.io/api7/aisix-cp-{api,dpm,ui}:0.9.0` and `docker.io/api7/aisix:0.9.0`, with the startupProbe rendering `failureThreshold: 360`.

Merging publishes `aisix-cp-0.9.0` and `aisix-0.9.0` to charts.api7.ai.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released application and Helm charts as version 0.9.0.
  * Improved startup handling to allow up to 30 minutes for initial migrations and scaling.

* **Documentation**
  * Updated chart documentation and version badges to reflect the 0.9.0 release.
  * Added guidance about startup duration and first-start behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->